### PR TITLE
✨ Introduce many-to-many relationship for filaments

### DIFF
--- a/src/gCodeJournal.Model/GCodeJournalDbContext.cs
+++ b/src/gCodeJournal.Model/GCodeJournalDbContext.cs
@@ -201,6 +201,12 @@ public class GCodeJournalDbContext : DbContext
                 CostPerWeight    = 19.95M
             });
 
+        // Configure many-to-many relationship between PrintingProject and Filament
+        modelBuilder.Entity<PrintingProject>()
+                    .HasMany(p => p.Filaments)
+                    .WithMany(f => f.Projects)
+                    .UsingEntity(j => j.ToTable("PrintingProjectFilaments"));
+
         // Call the base method
         base.OnModelCreating(modelBuilder);
     }

--- a/src/gCodeJournal.Model/Migrations/20251116005138_MultipleFilamentsPerProject.Designer.cs
+++ b/src/gCodeJournal.Model/Migrations/20251116005138_MultipleFilamentsPerProject.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using gCodeJournal.Model;
 
@@ -10,9 +11,11 @@ using gCodeJournal.Model;
 namespace gCodeJournal.Model.Migrations
 {
     [DbContext(typeof(GCodeJournalDbContext))]
-    partial class GCodeJournalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251116005138_MultipleFilamentsPerProject")]
+    partial class MultipleFilamentsPerProject
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/gCodeJournal.Model/Migrations/20251116005138_MultipleFilamentsPerProject.cs
+++ b/src/gCodeJournal.Model/Migrations/20251116005138_MultipleFilamentsPerProject.cs
@@ -1,0 +1,105 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace gCodeJournal.Model.Migrations
+{
+    /// <inheritdoc />
+    public partial class MultipleFilamentsPerProject : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Filaments_PrintingProjects_PrintingProjectId",
+                table: "Filaments");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Filaments_PrintingProjectId",
+                table: "Filaments");
+
+            migrationBuilder.DropColumn(
+                name: "FilamentId",
+                table: "PrintingProjects");
+
+            migrationBuilder.DropColumn(
+                name: "PrintingProjectId",
+                table: "Filaments");
+
+            migrationBuilder.CreateTable(
+                name: "PrintingProjectFilaments",
+                columns: table => new
+                {
+                    FilamentsId = table.Column<int>(type: "INTEGER", nullable: false),
+                    ProjectsId = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PrintingProjectFilaments", x => new { x.FilamentsId, x.ProjectsId });
+                    table.ForeignKey(
+                        name: "FK_PrintingProjectFilaments_Filaments_FilamentsId",
+                        column: x => x.FilamentsId,
+                        principalTable: "Filaments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_PrintingProjectFilaments_PrintingProjects_ProjectsId",
+                        column: x => x.ProjectsId,
+                        principalTable: "PrintingProjects",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PrintingProjectFilaments_ProjectsId",
+                table: "PrintingProjectFilaments",
+                column: "ProjectsId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PrintingProjectFilaments");
+
+            migrationBuilder.AddColumn<int>(
+                name: "FilamentId",
+                table: "PrintingProjects",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PrintingProjectId",
+                table: "Filaments",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "Filaments",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "PrintingProjectId",
+                value: null);
+
+            migrationBuilder.UpdateData(
+                table: "Filaments",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "PrintingProjectId",
+                value: null);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Filaments_PrintingProjectId",
+                table: "Filaments",
+                column: "PrintingProjectId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Filaments_PrintingProjects_PrintingProjectId",
+                table: "Filaments",
+                column: "PrintingProjectId",
+                principalTable: "PrintingProjects",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/src/gCodeJournal.Model/Models/Filament.cs
+++ b/src/gCodeJournal.Model/Models/Filament.cs
@@ -3,10 +3,8 @@
 namespace gCodeJournal.Model;
 
 #region Using Directives
-#region Using Directives
 using System.ComponentModel.DataAnnotations;
 using JetBrains.Annotations;
-#endregion
 #endregion
 
 /// <summary>
@@ -67,6 +65,12 @@ public class Filament
     /// </remarks>
     [StringLength(20)]
     public string? ProductId {get; set;}
+
+    /// <summary>
+    ///     Navigation property: the printing projects that reference this filament.
+    ///     Many-to-many relationship: a filament can be used by zero or more projects.
+    /// </summary>
+    public virtual ICollection<PrintingProject> Projects {get; set;} = new List<PrintingProject>();
 
     /// <summary>
     ///     Gets or sets the URL link to reorder this filament.

--- a/src/gCodeJournal.Model/Models/PrintingProject.cs
+++ b/src/gCodeJournal.Model/Models/PrintingProject.cs
@@ -3,6 +3,7 @@
 namespace gCodeJournal.Model;
 
 #region Using Directives
+using System.Collections.Generic;
 using JetBrains.Annotations;
 #endregion
 
@@ -53,19 +54,13 @@ public class PrintingProject
     public int CustomerId {get; set;}
 
     /// <summary>
-    ///     Foreign key identifier referencing the primary filament used for this project.
-    /// </summary>
-    /// <value>An integer representing the filament record's primary key.</value>
-    public int FilamentId {get; set;}
-
-    /// <summary>
     ///     Navigation property: collection of filament records associated with this project.
     /// </summary>
     /// <value>
     ///     A collection of <see cref="Filament" /> instances; expected to be non-null when the entity
-    ///     is in a valid state (may be empty if no specific filaments are recorded).
+    ///     is in a valid state (can be empty if no specific filaments are recorded).
     /// </value>
-    public virtual ICollection<Filament> Filaments {get; set;} = null!;
+    public virtual ICollection<Filament> Filaments {get; set;} = new List<Filament>();
 
     /// <summary>
     ///     Primary key identifier for the printing project.


### PR DESCRIPTION
✨ Introduce many-to-many relationship for filaments

🗃️ Updated `GCodeJournalDbContext` to configure a many-to-many relationship between `PrintingProject` and `Filament` using the `PrintingProjectFilaments` join table.
🗃️ Generated migration `20251116005138_MultipleFilamentsPerProject` to implement the many-to-many relationship, removing the old one-to-many relationship.
🗃️ Updated `GCodeJournalDbContextModelSnapshot` to reflect the new relationship.
✨ Added navigation property `Projects` to `Filament` to support the many-to-many relationship.
🔥 Removed `FilamentId` from `PrintingProject` and added a navigation property `Filaments` for the new relationship.
♻️ Refactored `GCodeJournalViewModel` to handle multiple filaments for a single project, including logic to find or create `Filament` entities.
🗃️ Adjusted seed data to align with the new many-to-many relationship.
🔥 Removed obsolete properties and navigation logic related to the old one-to-many relationship.
📝 Updated comments and documentation to reflect the new relationship.

Closes #9 