### PR TITLE
Add support for Printer records

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,4 @@
+# Copilot Instructions
+
+## Project Guidelines
+- User's development environment: Visual Studio Enterprise 2026 on Windows; workspace root I:\source\gCodeJournal; preferred shell pwsh.exe.

--- a/src/gCodeJournal.Model/GCodeJournalDbContext.cs
+++ b/src/gCodeJournal.Model/GCodeJournalDbContext.cs
@@ -232,7 +232,8 @@ public class GCodeJournalDbContext : DbContext
 
             b.HasIndex("ManufacturerId");
 
-            b.ToTable("Printer");
+            // Use plural table name to match project conventions and existing DbSet
+            b.ToTable("Printers");
         });
     }
     #endregion

--- a/src/gCodeJournal.Model/GCodeJournalDbContext.cs
+++ b/src/gCodeJournal.Model/GCodeJournalDbContext.cs
@@ -100,6 +100,11 @@ public class GCodeJournalDbContext : DbContext
     ///     is used to track submission/completion timestamps, cost and associated filaments and customer.
     /// </remarks>
     public DbSet<PrintingProject> PrintingProjects {get; set;} = null!;
+
+    /// <summary>
+    ///     Gets or sets the collection of <see cref="Printer" /> entities.
+    /// </summary>
+    public DbSet<Printer> Printers { get; set; } = null!;
     #endregion
 
     internal static string GetDefaultDbPath()
@@ -209,6 +214,26 @@ public class GCodeJournalDbContext : DbContext
 
         // Call the base method
         base.OnModelCreating(modelBuilder);
+        modelBuilder.Entity<Printer>(b =>
+        {
+            b.Property<int>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("INTEGER");
+
+            b.Property<int>("ManufacturerId")
+                .HasColumnType("INTEGER");
+
+            b.Property<string>("Model")
+                .IsRequired()
+                .HasMaxLength(50)
+                .HasColumnType("TEXT");
+
+            b.HasKey("Id");
+
+            b.HasIndex("ManufacturerId");
+
+            b.ToTable("Printer");
+        });
     }
     #endregion
 }

--- a/src/gCodeJournal.Model/Migrations/20260411040853_AddPrinterEntity.Designer.cs
+++ b/src/gCodeJournal.Model/Migrations/20260411040853_AddPrinterEntity.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using gCodeJournal.Model;
 
@@ -10,9 +11,11 @@ using gCodeJournal.Model;
 namespace gCodeJournal.Model.Migrations
 {
     [DbContext(typeof(GCodeJournalDbContext))]
-    partial class GCodeJournalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411040853_AddPrinterEntity")]
+    partial class AddPrinterEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/gCodeJournal.Model/Migrations/20260411040853_AddPrinterEntity.Designer.cs
+++ b/src/gCodeJournal.Model/Migrations/20260411040853_AddPrinterEntity.Designer.cs
@@ -380,7 +380,7 @@ namespace gCodeJournal.Model.Migrations
 
                     b.HasIndex("ManufacturerId");
 
-                    b.ToTable("Printer");
+                    b.ToTable("Printers");
                 });
 
             modelBuilder.Entity("gCodeJournal.Model.PrintingProject", b =>

--- a/src/gCodeJournal.Model/Migrations/20260411040853_AddPrinterEntity.cs
+++ b/src/gCodeJournal.Model/Migrations/20260411040853_AddPrinterEntity.cs
@@ -25,7 +25,7 @@ namespace gCodeJournal.Model.Migrations
                 defaultValue: false);
 
             migrationBuilder.CreateTable(
-                name: "Printer",
+                name: "Printers",
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "INTEGER", nullable: false)
@@ -35,9 +35,9 @@ namespace gCodeJournal.Model.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_Printer", x => x.Id);
+                    table.PrimaryKey("PK_Printers", x => x.Id);
                     table.ForeignKey(
-                        name: "FK_Printer_Manufacturers_ManufacturerId",
+                        name: "FK_Printers_Manufacturers_ManufacturerId",
                         column: x => x.ManufacturerId,
                         principalTable: "Manufacturers",
                         principalColumn: "Id",
@@ -94,8 +94,8 @@ namespace gCodeJournal.Model.Migrations
                 values: new object[] { true, true });
 
             migrationBuilder.CreateIndex(
-                name: "IX_Printer_ManufacturerId",
-                table: "Printer",
+                name: "IX_Printers_ManufacturerId",
+                table: "Printers",
                 column: "ManufacturerId");
         }
 
@@ -103,7 +103,7 @@ namespace gCodeJournal.Model.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
-                name: "Printer");
+                name: "Printers");
 
             migrationBuilder.DropColumn(
                 name: "IsFilamentManufacturer",

--- a/src/gCodeJournal.Model/Migrations/20260411040853_AddPrinterEntity.cs
+++ b/src/gCodeJournal.Model/Migrations/20260411040853_AddPrinterEntity.cs
@@ -1,0 +1,117 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace gCodeJournal.Model.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPrinterEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsFilamentManufacturer",
+                table: "Manufacturers",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsPrinterManufacturer",
+                table: "Manufacturers",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateTable(
+                name: "Printer",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    ManufacturerId = table.Column<int>(type: "INTEGER", nullable: false),
+                    Model = table.Column<string>(type: "TEXT", maxLength: 50, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Printer", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Printer_Manufacturers_ManufacturerId",
+                        column: x => x.ManufacturerId,
+                        principalTable: "Manufacturers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.UpdateData(
+                table: "Manufacturers",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "IsFilamentManufacturer", "IsPrinterManufacturer" },
+                values: new object[] { true,true });
+
+            migrationBuilder.UpdateData(
+                table: "Manufacturers",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "IsFilamentManufacturer", "IsPrinterManufacturer" },
+                values: new object[] { true, false });
+
+            migrationBuilder.UpdateData(
+                table: "Manufacturers",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "IsFilamentManufacturer", "IsPrinterManufacturer" },
+                values: new object[] { true, false });
+
+            migrationBuilder.UpdateData(
+                table: "Manufacturers",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "IsFilamentManufacturer", "IsPrinterManufacturer" },
+                values: new object[] { true, true });
+
+            migrationBuilder.UpdateData(
+                table: "Manufacturers",
+                keyColumn: "Id",
+                keyValue: 5,
+                columns: new[] { "IsFilamentManufacturer", "IsPrinterManufacturer" },
+                values: new object[] { true, true });
+
+            migrationBuilder.UpdateData(
+                table: "Manufacturers",
+                keyColumn: "Id",
+                keyValue: 6,
+                columns: new[] { "IsFilamentManufacturer", "IsPrinterManufacturer" },
+                values: new object[] { true, false });
+
+            migrationBuilder.UpdateData(
+                table: "Manufacturers",
+                keyColumn: "Id",
+                keyValue: 7,
+                columns: new[] { "IsFilamentManufacturer", "IsPrinterManufacturer" },
+                values: new object[] { true, true });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Printer_ManufacturerId",
+                table: "Printer",
+                column: "ManufacturerId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Printer");
+
+            migrationBuilder.DropColumn(
+                name: "IsFilamentManufacturer",
+                table: "Manufacturers");
+
+            migrationBuilder.DropColumn(
+                name: "IsPrinterManufacturer",
+                table: "Manufacturers");
+        }
+    }
+}

--- a/src/gCodeJournal.Model/Migrations/20260411051431_AddCostToPrinterEntity.Designer.cs
+++ b/src/gCodeJournal.Model/Migrations/20260411051431_AddCostToPrinterEntity.Designer.cs
@@ -383,7 +383,7 @@ namespace gCodeJournal.Model.Migrations
 
                     b.HasIndex("ManufacturerId");
 
-                    b.ToTable("Printer", (string)null);
+                    b.ToTable("Printers", (string)null);
                 });
 
             modelBuilder.Entity("gCodeJournal.Model.PrintingProject", b =>

--- a/src/gCodeJournal.Model/Migrations/20260411051431_AddCostToPrinterEntity.Designer.cs
+++ b/src/gCodeJournal.Model/Migrations/20260411051431_AddCostToPrinterEntity.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using gCodeJournal.Model;
 
@@ -10,9 +11,11 @@ using gCodeJournal.Model;
 namespace gCodeJournal.Model.Migrations
 {
     [DbContext(typeof(GCodeJournalDbContext))]
-    partial class GCodeJournalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411051431_AddCostToPrinterEntity")]
+    partial class AddCostToPrinterEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/gCodeJournal.Model/Migrations/20260411051431_AddCostToPrinterEntity.cs
+++ b/src/gCodeJournal.Model/Migrations/20260411051431_AddCostToPrinterEntity.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace gCodeJournal.Model.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCostToPrinterEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "CostPerHour",
+                table: "Printer",
+                type: "money",
+                nullable: false,
+                defaultValue: 0m);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CostPerHour",
+                table: "Printer");
+        }
+    }
+}

--- a/src/gCodeJournal.Model/Migrations/20260411051431_AddCostToPrinterEntity.cs
+++ b/src/gCodeJournal.Model/Migrations/20260411051431_AddCostToPrinterEntity.cs
@@ -12,7 +12,7 @@ namespace gCodeJournal.Model.Migrations
         {
             migrationBuilder.AddColumn<decimal>(
                 name: "CostPerHour",
-                table: "Printer",
+                table: "Printers",
                 type: "money",
                 nullable: false,
                 defaultValue: 0m);
@@ -23,7 +23,7 @@ namespace gCodeJournal.Model.Migrations
         {
             migrationBuilder.DropColumn(
                 name: "CostPerHour",
-                table: "Printer");
+                table: "Printers");
         }
     }
 }

--- a/src/gCodeJournal.Model/Migrations/20260411051727_UpdateProjectCost.Designer.cs
+++ b/src/gCodeJournal.Model/Migrations/20260411051727_UpdateProjectCost.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using gCodeJournal.Model;
 
@@ -10,9 +11,11 @@ using gCodeJournal.Model;
 namespace gCodeJournal.Model.Migrations
 {
     [DbContext(typeof(GCodeJournalDbContext))]
-    partial class GCodeJournalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411051727_UpdateProjectCost")]
+    partial class UpdateProjectCost
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/gCodeJournal.Model/Migrations/20260411051727_UpdateProjectCost.Designer.cs
+++ b/src/gCodeJournal.Model/Migrations/20260411051727_UpdateProjectCost.Designer.cs
@@ -383,7 +383,7 @@ namespace gCodeJournal.Model.Migrations
 
                     b.HasIndex("ManufacturerId");
 
-                    b.ToTable("Printer", (string)null);
+                    b.ToTable("Printers", (string)null);
                 });
 
             modelBuilder.Entity("gCodeJournal.Model.PrintingProject", b =>

--- a/src/gCodeJournal.Model/Migrations/20260411051727_UpdateProjectCost.cs
+++ b/src/gCodeJournal.Model/Migrations/20260411051727_UpdateProjectCost.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace gCodeJournal.Model.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateProjectCost : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Cost",
+                table: "PrintingProjects",
+                type: "money",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "TEXT");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Cost",
+                table: "PrintingProjects",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "money");
+        }
+    }
+}

--- a/src/gCodeJournal.Model/Migrations/20260411054056_AddPrinterToProject.Designer.cs
+++ b/src/gCodeJournal.Model/Migrations/20260411054056_AddPrinterToProject.Designer.cs
@@ -383,7 +383,7 @@ namespace gCodeJournal.Model.Migrations
 
                     b.HasIndex("ManufacturerId");
 
-                    b.ToTable("Printer", (string)null);
+                    b.ToTable("Printers", (string)null);
                 });
 
             modelBuilder.Entity("gCodeJournal.Model.PrintingProject", b =>

--- a/src/gCodeJournal.Model/Migrations/20260411054056_AddPrinterToProject.Designer.cs
+++ b/src/gCodeJournal.Model/Migrations/20260411054056_AddPrinterToProject.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using gCodeJournal.Model;
 
@@ -10,9 +11,11 @@ using gCodeJournal.Model;
 namespace gCodeJournal.Model.Migrations
 {
     [DbContext(typeof(GCodeJournalDbContext))]
-    partial class GCodeJournalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411054056_AddPrinterToProject")]
+    partial class AddPrinterToProject
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/gCodeJournal.Model/Migrations/20260411054056_AddPrinterToProject.cs
+++ b/src/gCodeJournal.Model/Migrations/20260411054056_AddPrinterToProject.cs
@@ -23,10 +23,10 @@ namespace gCodeJournal.Model.Migrations
                 column: "PrinterId");
 
             migrationBuilder.AddForeignKey(
-                name: "FK_PrintingProjects_Printer_PrinterId",
+                name: "FK_PrintingProjects_Printers_PrinterId",
                 table: "PrintingProjects",
                 column: "PrinterId",
-                principalTable: "Printer",
+                principalTable: "Printers",
                 principalColumn: "Id",
                 onDelete: ReferentialAction.Cascade);
         }
@@ -35,7 +35,7 @@ namespace gCodeJournal.Model.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropForeignKey(
-                name: "FK_PrintingProjects_Printer_PrinterId",
+                name: "FK_PrintingProjects_Printers_PrinterId",
                 table: "PrintingProjects");
 
             migrationBuilder.DropIndex(

--- a/src/gCodeJournal.Model/Migrations/20260411054056_AddPrinterToProject.cs
+++ b/src/gCodeJournal.Model/Migrations/20260411054056_AddPrinterToProject.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace gCodeJournal.Model.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPrinterToProject : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "PrinterId",
+                table: "PrintingProjects",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PrintingProjects_PrinterId",
+                table: "PrintingProjects",
+                column: "PrinterId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PrintingProjects_Printer_PrinterId",
+                table: "PrintingProjects",
+                column: "PrinterId",
+                principalTable: "Printer",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PrintingProjects_Printer_PrinterId",
+                table: "PrintingProjects");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PrintingProjects_PrinterId",
+                table: "PrintingProjects");
+
+            migrationBuilder.DropColumn(
+                name: "PrinterId",
+                table: "PrintingProjects");
+        }
+    }
+}

--- a/src/gCodeJournal.Model/Migrations/GCodeJournalDbContextModelSnapshot.cs
+++ b/src/gCodeJournal.Model/Migrations/GCodeJournalDbContextModelSnapshot.cs
@@ -380,7 +380,7 @@ namespace gCodeJournal.Model.Migrations
 
                     b.HasIndex("ManufacturerId");
 
-                    b.ToTable("Printer", (string)null);
+                    b.ToTable("Printers", (string)null);
                 });
 
             modelBuilder.Entity("gCodeJournal.Model.PrintingProject", b =>

--- a/src/gCodeJournal.Model/Models/Manufacturer.cs
+++ b/src/gCodeJournal.Model/Models/Manufacturer.cs
@@ -32,10 +32,39 @@ public class Manufacturer
     public int Id {get; set;}
 
     /// <summary>
+    ///     Gets or sets a value indicating whether the manufacturer produces 3D printing filament.
+    /// </summary>
+    /// <value>
+    ///     <c>true</c> if the manufacturer produces filament; otherwise, <c>false</c>.
+    /// </value>
+    public bool IsFilamentManufacturer {get; set;}
+
+    /// <summary>
+    ///     Gets or sets a value indicating whether the manufacturer produces 3D printers.
+    /// </summary>
+    /// <value>
+    ///     <c>true</c> if the manufacturer produces 3D printers; otherwise, <c>false</c>.
+    /// </value>
+    /// <remarks>
+    ///     This property helps distinguish manufacturers that produce 3D printers
+    ///     from those that exclusively produce other products, such as 3D printing filament.
+    /// </remarks>
+    public bool IsPrinterManufacturer {get; set;}
+
+    /// <summary>
     ///     A human-readable name for the manufacturer (for example, "Prusa" or "Hatchbox").
     /// </summary>
     [StringLength(30)]
     public string Name {get; set;} = null!;
+
+    /// <summary>
+    ///     Gets or sets the collection of 3D printers associated with this manufacturer.
+    /// </summary>
+    /// <remarks>
+    ///     This property represents the printers produced by the manufacturer. Each printer
+    ///     includes details such as its model and manufacturer information.
+    /// </remarks>
+    public virtual ICollection<Printer> Printers {get; set;} = null!;
     #endregion
 
     #region Overrides of Object

--- a/src/gCodeJournal.Model/Models/Manufacturer.cs
+++ b/src/gCodeJournal.Model/Models/Manufacturer.cs
@@ -3,10 +3,8 @@
 namespace gCodeJournal.Model;
 
 #region Using Directives
-#region Using Directives
 using System.ComponentModel.DataAnnotations;
 using JetBrains.Annotations;
-#endregion
 #endregion
 
 /// <summary>

--- a/src/gCodeJournal.Model/Models/Printer.cs
+++ b/src/gCodeJournal.Model/Models/Printer.cs
@@ -1,0 +1,61 @@
+﻿// gCodeJournal.Model
+
+namespace gCodeJournal.Model;
+
+#region Using Directives
+using System.ComponentModel.DataAnnotations;
+#endregion
+
+/// <summary>
+///     Represents a 3D printer, including its manufacturer and model information.
+/// </summary>
+/// <remarks>
+///     This class is used to store details about a specific 3D printer, such as its
+///     manufacturer and model. It can be associated with other entities in the system
+///     to track printer-specific data.
+/// </remarks>
+public class Printer
+{
+    #region Properties
+    /// <summary>
+    ///     Gets or sets the unique identifier for the printer.
+    /// </summary>
+    /// <value>
+    ///     An integer representing the unique identifier of the printer.
+    /// </value>
+    /// <remarks>
+    ///     This property is used as the primary key for the <see cref="Printer" /> entity.
+    /// </remarks>
+    public int Id {get; set;}
+
+    /// <summary>
+    ///     Gets or sets the manufacturer of the 3D printer.
+    /// </summary>
+    /// <remarks>
+    ///     This property represents the manufacturer associated with the 3D printer.
+    ///     It provides a reference to the <see cref="Manufacturer" /> entity, which contains
+    ///     details about the vendor or brand of the printer.
+    /// </remarks>
+    public virtual Manufacturer Manufacturer {get; set;} = null!;
+
+    /// <summary>
+    ///     Gets or sets the identifier of the manufacturer associated with the printer.
+    /// </summary>
+    /// <remarks>
+    ///     This property serves as a foreign key linking the printer to its corresponding
+    ///     <see cref="Manufacturer" /> entity. It is used to establish the relationship
+    ///     between the printer and its manufacturer in the database.
+    /// </remarks>
+    public int ManufacturerId {get; set;}
+
+    /// <summary>
+    ///     Gets or sets the model name of the 3D printer.
+    /// </summary>
+    /// <remarks>
+    ///     This property represents the specific model of the 3D printer, such as "Prusa i3 MK3S" or "Ender 3".
+    ///     It is limited to a maximum length of 50 characters.
+    /// </remarks>
+    [StringLength(50)]
+    public string Model {get; set;} = null!;
+    #endregion
+}

--- a/src/gCodeJournal.Model/Models/Printer.cs
+++ b/src/gCodeJournal.Model/Models/Printer.cs
@@ -19,6 +19,15 @@ public class Printer
 {
     #region Properties
     /// <summary>
+    ///     Gets or sets the labour cost per hour for using this printer.
+    /// </summary>
+    /// <remarks>
+    ///     This value is stored as a currency/money value in the database.
+    /// </remarks>
+    [Column(TypeName = "money")]
+    public decimal CostPerHour {get; set;}
+
+    /// <summary>
     ///     Gets or sets the unique identifier for the printer.
     /// </summary>
     /// <value>
@@ -50,15 +59,6 @@ public class Printer
     public int ManufacturerId {get; set;}
 
     /// <summary>
-    ///     Gets or sets the labour cost per hour for using this printer.
-    /// </summary>
-    /// <remarks>
-    ///     This value is stored as a currency/money value in the database.
-    /// </remarks>
-    [Column(TypeName = "money")]
-    public decimal CostPerHour { get; set; } = 0m;
-
-    /// <summary>
     ///     Gets or sets the model name of the 3D printer.
     /// </summary>
     /// <remarks>
@@ -67,5 +67,7 @@ public class Printer
     /// </remarks>
     [StringLength(50)]
     public string Model {get; set;} = null!;
+
+    public virtual ICollection<PrintingProject> PrintingProjects {get; set;} = null!;
     #endregion
 }

--- a/src/gCodeJournal.Model/Models/Printer.cs
+++ b/src/gCodeJournal.Model/Models/Printer.cs
@@ -4,6 +4,7 @@ namespace gCodeJournal.Model;
 
 #region Using Directives
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 #endregion
 
 /// <summary>
@@ -47,6 +48,15 @@ public class Printer
     ///     between the printer and its manufacturer in the database.
     /// </remarks>
     public int ManufacturerId {get; set;}
+
+    /// <summary>
+    ///     Gets or sets the labour cost per hour for using this printer.
+    /// </summary>
+    /// <remarks>
+    ///     This value is stored as a currency/money value in the database.
+    /// </remarks>
+    [Column(TypeName = "money")]
+    public decimal CostPerHour { get; set; } = 0m;
 
     /// <summary>
     ///     Gets or sets the model name of the 3D printer.

--- a/src/gCodeJournal.Model/Models/PrintingProject.cs
+++ b/src/gCodeJournal.Model/Models/PrintingProject.cs
@@ -4,6 +4,7 @@ namespace gCodeJournal.Model;
 
 #region Using Directives
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 using JetBrains.Annotations;
 #endregion
 
@@ -36,7 +37,8 @@ public class PrintingProject
     ///     A <see cref="decimal" /> value representing the monetary cost. Uses <see cref="decimal" />
     ///     to preserve precision for currency amounts.
     /// </value>
-    public decimal Cost {get; set;}
+    [Column(TypeName = "money")]
+    public decimal Cost {get; set;} 
 
     /// <summary>
     ///     Navigation property: the customer who requested the printing project.

--- a/src/gCodeJournal.Model/Models/PrintingProject.cs
+++ b/src/gCodeJournal.Model/Models/PrintingProject.cs
@@ -3,7 +3,6 @@
 namespace gCodeJournal.Model;
 
 #region Using Directives
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using JetBrains.Annotations;
 #endregion
@@ -38,7 +37,7 @@ public class PrintingProject
     ///     to preserve precision for currency amounts.
     /// </value>
     [Column(TypeName = "money")]
-    public decimal Cost {get; set;} 
+    public decimal Cost {get; set;}
 
     /// <summary>
     ///     Navigation property: the customer who requested the printing project.
@@ -84,6 +83,15 @@ public class PrintingProject
     /// </summary>
     /// <value>An integer representing the model design's primary key.</value>
     public int ModelDesignId {get; set;}
+
+    /// <summary>
+    ///     Gets or sets the <see cref="Printer" /> associated with this printing project.
+    /// </summary>
+    /// <remarks>
+    ///     This property represents the specific 3D printer used to fulfill the printing project.
+    ///     It provides details about the printer, including its manufacturer and model information.
+    /// </remarks>
+    public virtual Printer Printer {get; set;} = null!;
 
     /// <summary>
     ///     Gets or sets the date and time when the project was submitted.

--- a/src/gCodeJournal.ViewModel/DTOs/CustomerDto.cs
+++ b/src/gCodeJournal.ViewModel/DTOs/CustomerDto.cs
@@ -2,6 +2,10 @@
 
 namespace gCodeJournal.ViewModel.DTOs;
 
+#region Using Directives
+using Model;
+#endregion
+
 /// <summary>
 ///     Represents a customer with an ID and a name.
 /// </summary>
@@ -14,6 +18,9 @@ public class CustomerDto(int id, string name)
 
     /// <inheritdoc />
     public CustomerDto(string name) : this(0, name) {}
+
+    /// <inheritdoc />
+    public CustomerDto(Customer customer) : this(customer.Id, customer.Name) {}
     #endregion
 
     #region Properties

--- a/src/gCodeJournal.ViewModel/DTOs/FilamentColourDto.cs
+++ b/src/gCodeJournal.ViewModel/DTOs/FilamentColourDto.cs
@@ -2,6 +2,10 @@
 
 namespace gCodeJournal.ViewModel.DTOs;
 
+#region Using Directives
+using Model;
+#endregion
+
 /// <summary>
 ///     Represents a filament color with an ID and a description.
 /// </summary>
@@ -12,6 +16,9 @@ public class FilamentColourDto(int id, string description)
 
     /// <inheritdoc />
     public FilamentColourDto(string description) : this(0, description) {}
+
+    /// <inheritdoc />
+    public FilamentColourDto(FilamentColour filamentColour) : this(filamentColour.Id, filamentColour.Description) {}
     #endregion
 
     #region Properties

--- a/src/gCodeJournal.ViewModel/DTOs/FilamentDto.cs
+++ b/src/gCodeJournal.ViewModel/DTOs/FilamentDto.cs
@@ -1,4 +1,10 @@
+// gCodeJournal.ViewModel
+
 namespace gCodeJournal.ViewModel.DTOs;
+
+#region Using Directives
+using Model;
+#endregion
 
 /// <summary>
 ///     Represents a filament with various properties such as cost, product ID, reorder link, color, type, and
@@ -14,12 +20,16 @@ public class FilamentDto(
     ManufacturerDto   manufacturer)
 {
     #region Constructors
-    /// <summary>
-    /// Parameterless constructor required by some serializers and CsvHelper when no factory is provided.
-    /// Creates a minimal instance with default nested DTOs.
-    /// </summary>
-    public FilamentDto()
-        : this(0, 0m, null, null, new FilamentColourDto(0, string.Empty), new FilamentTypeDto(0, string.Empty), new ManufacturerDto(0, string.Empty)) { }
+    /// <inheritdoc />
+    public FilamentDto() : this(
+        0,
+        0m,
+        null,
+        null,
+        new FilamentColourDto(0, string.Empty),
+        new FilamentTypeDto(0, string.Empty),
+        new ManufacturerDto(0, string.Empty)) {}
+
     /// <inheritdoc />
     public FilamentDto(
         decimal           costPerWeight,
@@ -28,6 +38,15 @@ public class FilamentDto(
         FilamentColourDto filamentColour,
         FilamentTypeDto   filamentType,
         ManufacturerDto   manufacturer) : this(0, costPerWeight, productId, reorderLink, filamentColour, filamentType, manufacturer) {}
+
+    public FilamentDto(Filament filament) : this(
+        filament.Id,
+        filament.CostPerWeight,
+        filament.ProductId,
+        filament.ReorderLink,
+        new FilamentColourDto(filament.Colour),
+        new FilamentTypeDto(filament.Type),
+        new ManufacturerDto(filament.Manufacturer)) {}
     #endregion
 
     #region Properties

--- a/src/gCodeJournal.ViewModel/DTOs/FilamentTypeDto.cs
+++ b/src/gCodeJournal.ViewModel/DTOs/FilamentTypeDto.cs
@@ -2,6 +2,10 @@
 
 namespace gCodeJournal.ViewModel.DTOs;
 
+#region Using Directives
+using Model;
+#endregion
+
 /// <summary>
 ///     Represents a filament type with an ID and a description.
 /// </summary>
@@ -12,6 +16,9 @@ public class FilamentTypeDto(int id, string description)
 
     /// <inheritdoc />
     public FilamentTypeDto(string description) : this(0, description) {}
+
+    /// <inheritdoc />
+    public FilamentTypeDto(FilamentType filamentType) : this(filamentType.Id, filamentType.Description) {}
     #endregion
 
     #region Properties

--- a/src/gCodeJournal.ViewModel/DTOs/ManufacturerDto.cs
+++ b/src/gCodeJournal.ViewModel/DTOs/ManufacturerDto.cs
@@ -9,6 +9,8 @@ public class ManufacturerDto(int id, string name, bool isFilamentManufacturer = 
 {
     #region Constructors
     public ManufacturerDto() : this(0, "") {}
+    // Explicit two-argument constructor avoids optional-argument expansion in expression trees
+    public ManufacturerDto(int id, string name) : this(id, name, false, false) {}
 
     /// <inheritdoc />
     public ManufacturerDto(string name) : this(0, name) {}

--- a/src/gCodeJournal.ViewModel/DTOs/ManufacturerDto.cs
+++ b/src/gCodeJournal.ViewModel/DTOs/ManufacturerDto.cs
@@ -2,6 +2,10 @@
 
 namespace gCodeJournal.ViewModel.DTOs;
 
+#region Using Directives
+using Model;
+#endregion
+
 /// <summary>
 ///     Represents a manufacturer with an ID and a name.
 /// </summary>
@@ -9,11 +13,18 @@ public class ManufacturerDto(int id, string name, bool isFilamentManufacturer = 
 {
     #region Constructors
     public ManufacturerDto() : this(0, "") {}
+
     // Explicit two-argument constructor avoids optional-argument expansion in expression trees
-    public ManufacturerDto(int id, string name) : this(id, name, false, false) {}
+    public ManufacturerDto(int id, string name) : this(id, name, false) {}
 
     /// <inheritdoc />
     public ManufacturerDto(string name) : this(0, name) {}
+
+    public ManufacturerDto(Manufacturer manufacturer) : this(
+        manufacturer.Id,
+        manufacturer.Name,
+        manufacturer.IsFilamentManufacturer,
+        manufacturer.IsPrinterManufacturer) {}
     #endregion
 
     #region Properties

--- a/src/gCodeJournal.ViewModel/DTOs/ManufacturerDto.cs
+++ b/src/gCodeJournal.ViewModel/DTOs/ManufacturerDto.cs
@@ -14,9 +14,6 @@ public class ManufacturerDto(int id, string name, bool isFilamentManufacturer = 
     #region Constructors
     public ManufacturerDto() : this(0, "") {}
 
-    // Explicit two-argument constructor avoids optional-argument expansion in expression trees
-    public ManufacturerDto(int id, string name) : this(id, name, false) {}
-
     /// <inheritdoc />
     public ManufacturerDto(string name) : this(0, name) {}
 

--- a/src/gCodeJournal.ViewModel/DTOs/ManufacturerDto.cs
+++ b/src/gCodeJournal.ViewModel/DTOs/ManufacturerDto.cs
@@ -5,7 +5,7 @@ namespace gCodeJournal.ViewModel.DTOs;
 /// <summary>
 ///     Represents a manufacturer with an ID and a name.
 /// </summary>
-public class ManufacturerDto(int id, string name)
+public class ManufacturerDto(int id, string name, bool isFilamentManufacturer = false, bool isPrinterManufacturer = false)
 {
     #region Constructors
     public ManufacturerDto() : this(0, "") {}
@@ -19,6 +19,22 @@ public class ManufacturerDto(int id, string name)
     ///     The unique identifier of the manufacturer.
     /// </summary>
     public int Id {get; init;} = id;
+
+    /// <summary>
+    ///     Gets a value indicating whether the manufacturer produces filament.
+    /// </summary>
+    /// <value>
+    ///     <c>true</c> if the manufacturer is a filament producer; otherwise, <c>false</c>.
+    /// </value>
+    public bool IsFilamentManufacturer {get; init;} = isFilamentManufacturer;
+
+    /// <summary>
+    ///     Gets a value indicating whether the manufacturer produces 3D printers.
+    /// </summary>
+    /// <value>
+    ///     <c>true</c> if the manufacturer produces 3D printers; otherwise, <c>false</c>.
+    /// </value>
+    public bool IsPrinterManufacturer {get; init;} = isPrinterManufacturer;
 
     /// <summary>
     ///     The name of the manufacturer.

--- a/src/gCodeJournal.ViewModel/DTOs/ModelDesignDto.cs
+++ b/src/gCodeJournal.ViewModel/DTOs/ModelDesignDto.cs
@@ -2,6 +2,10 @@
 
 namespace gCodeJournal.ViewModel.DTOs;
 
+#region Using Directives
+using Model;
+#endregion
+
 /// <summary>
 ///     Represents a model design with properties such as description, length, summary, and URL.
 /// </summary>
@@ -12,6 +16,9 @@ public class ModelDesignDto(int id, string description, decimal length, string s
 
     /// <inheritdoc />
     public ModelDesignDto(string description, decimal length, string summary, string? url) : this(0, description, length, summary, url) {}
+
+    /// <inheritdoc />
+    public ModelDesignDto(ModelDesign modelDesign) : this(modelDesign.Id, modelDesign.Description, modelDesign.Length, modelDesign.Summary, modelDesign.Url) {}
     #endregion
 
     #region Properties

--- a/src/gCodeJournal.ViewModel/DTOs/PrinterDto.cs
+++ b/src/gCodeJournal.ViewModel/DTOs/PrinterDto.cs
@@ -12,12 +12,17 @@ using Model;
 public class PrinterDto(int id, ManufacturerDto? manufacturer, string model, decimal costPerHour)
 {
     #region Constructors
+    /// <inheritdoc />
     public PrinterDto() : this(0, null, string.Empty, 0m) {}
 
+    /// <inheritdoc />
     public PrinterDto(int id, string model) : this(id, null, model, 0m) {}
 
+    /// <inheritdoc />
     public PrinterDto(ManufacturerDto manufacturer, string model, decimal costPerHour) : this(0, manufacturer, model, costPerHour) {}
-    public PrinterDto(Printer         printer) : this(printer.Id, new ManufacturerDto(printer.Manufacturer), printer.Model, printer.CostPerHour) {}
+
+    /// <inheritdoc />
+    public PrinterDto(Printer printer) : this(printer.Id, new ManufacturerDto(printer.Manufacturer), printer.Model, printer.CostPerHour) {}
     #endregion
 
     #region Properties

--- a/src/gCodeJournal.ViewModel/DTOs/PrinterDto.cs
+++ b/src/gCodeJournal.ViewModel/DTOs/PrinterDto.cs
@@ -1,0 +1,25 @@
+namespace gCodeJournal.ViewModel.DTOs;
+
+/// <summary>
+///     Represents a 3D printer DTO with an optional manufacturer reference.
+/// </summary>
+public class PrinterDto(int id, ManufacturerDto? manufacturer, string model)
+{
+    #region Constructors
+    public PrinterDto() : this(0, null, string.Empty) {}
+
+    public PrinterDto(int id, string model) : this(id, null, model) {}
+
+    public PrinterDto(ManufacturerDto manufacturer, string model) : this(0, manufacturer, model) {}
+    #endregion
+
+    #region Properties
+    public int Id {get; init;} = id;
+
+    public ManufacturerDto? Manufacturer {get; set;} = manufacturer;
+
+    public string Model {get; set;} = model;
+    #endregion
+
+    public override string ToString() => Model;
+}

--- a/src/gCodeJournal.ViewModel/DTOs/PrinterDto.cs
+++ b/src/gCodeJournal.ViewModel/DTOs/PrinterDto.cs
@@ -1,25 +1,32 @@
+// gCodeJournal.ViewModel
+
 namespace gCodeJournal.ViewModel.DTOs;
+
+#region Using Directives
+using Model;
+#endregion
 
 /// <summary>
 ///     Represents a 3D printer DTO with an optional manufacturer reference.
 /// </summary>
-public class PrinterDto(int id, ManufacturerDto? manufacturer, string model)
+public class PrinterDto(int id, ManufacturerDto? manufacturer, string model, decimal costPerHour)
 {
     #region Constructors
-    public PrinterDto() : this(0, null, string.Empty) {}
+    public PrinterDto() : this(0, null, string.Empty, 0m) {}
 
-    public PrinterDto(int id, string model) : this(id, null, model) {}
+    public PrinterDto(int id, string model) : this(id, null, model, 0m) {}
 
-    public PrinterDto(ManufacturerDto manufacturer, string model) : this(0, manufacturer, model) {}
+    public PrinterDto(ManufacturerDto manufacturer, string model, decimal costPerHour) : this(0, manufacturer, model, costPerHour) {}
+    public PrinterDto(Printer         printer) : this(printer.Id, new ManufacturerDto(printer.Manufacturer), printer.Model, printer.CostPerHour) {}
     #endregion
 
     #region Properties
-    public int Id {get; init;} = id;
-
-    public ManufacturerDto? Manufacturer {get; set;} = manufacturer;
+    public decimal          CostPerHour  {get; set;}  = costPerHour;
+    public int              Id           {get; init;} = id;
+    public ManufacturerDto? Manufacturer {get; set;}  = manufacturer;
 
     public string Model {get; set;} = model;
     #endregion
 
-    public override string ToString() => Model;
+    public override string ToString() => $"{Manufacturer?.Name} {Model}";
 }

--- a/src/gCodeJournal.ViewModel/DTOs/PrintingProjectDto.cs
+++ b/src/gCodeJournal.ViewModel/DTOs/PrintingProjectDto.cs
@@ -2,6 +2,10 @@
 
 namespace gCodeJournal.ViewModel.DTOs;
 
+#region Using Directives
+using Model;
+#endregion
+
 /// <summary>
 ///     Represents a printing project with various properties such as cost, submission and completion dates, customer,
 ///     model design, and filaments used.
@@ -21,6 +25,18 @@ public class PrintingProjectDto(
     ///     Parameterless constructor to support serializers and CsvHelper when a factory is not provided.
     /// </summary>
     public PrintingProjectDto() : this(0, 0m, DateOnly.FromDateTime(DateTime.Now), null, null, null, null, new List<FilamentDto>()) {}
+
+    public PrintingProjectDto(PrintingProject printingProject) : this()
+    {
+        Id          = printingProject.Id;
+        Cost        = printingProject.Cost;
+        Submitted   = DateOnly.FromDateTime(printingProject.Submitted);
+        Completed   = printingProject.Completed.HasValue ? DateOnly.FromDateTime(printingProject.Completed.Value) : null;
+        Customer    = new CustomerDto(printingProject.Customer);
+        ModelDesign = new ModelDesignDto(printingProject.Model);
+        Printer     = new PrinterDto(printingProject.Printer);
+        Filaments   = printingProject.Filaments.Select(f => new FilamentDto(f)).ToList();
+    }
 
     public PrintingProjectDto(
         decimal           cost,

--- a/src/gCodeJournal.ViewModel/DTOs/PrintingProjectDto.cs
+++ b/src/gCodeJournal.ViewModel/DTOs/PrintingProjectDto.cs
@@ -1,3 +1,5 @@
+// gCodeJournal.ViewModel
+
 namespace gCodeJournal.ViewModel.DTOs;
 
 /// <summary>
@@ -11,16 +13,23 @@ public class PrintingProjectDto(
     DateOnly?         completed,
     CustomerDto?      customer,
     ModelDesignDto?   modelDesign,
+    PrinterDto?       printer,
     List<FilamentDto> filaments)
 {
     #region Constructors
     /// <summary>
-    /// Parameterless constructor to support serializers and CsvHelper when a factory is not provided.
+    ///     Parameterless constructor to support serializers and CsvHelper when a factory is not provided.
     /// </summary>
-    public PrintingProjectDto()
-        : this(0, 0m, DateOnly.FromDateTime(DateTime.Now), null, null, null, new List<FilamentDto>()) { }
-    public PrintingProjectDto(decimal cost, DateOnly submitted, DateOnly? completed, CustomerDto? customer, ModelDesignDto? modelDesign, List<FilamentDto> filaments) :
-        this(0, cost, submitted, completed, customer, modelDesign, filaments) {}
+    public PrintingProjectDto() : this(0, 0m, DateOnly.FromDateTime(DateTime.Now), null, null, null, null, new List<FilamentDto>()) {}
+
+    public PrintingProjectDto(
+        decimal           cost,
+        DateOnly          submitted,
+        DateOnly?         completed,
+        CustomerDto?      customer,
+        ModelDesignDto?   modelDesign,
+        PrinterDto?       printer,
+        List<FilamentDto> filaments) : this(0, cost, submitted, completed, customer, modelDesign, printer, filaments) {}
     #endregion
 
     #region Properties
@@ -55,6 +64,11 @@ public class PrintingProjectDto(
     public ModelDesignDto? ModelDesign {get; set;} = modelDesign;
 
     /// <summary>
+    ///     The printer associated with the project (optional).
+    /// </summary>
+    public PrinterDto? Printer {get; set;} = printer;
+
+    /// <summary>
     ///     The date when the project was submitted.
     /// </summary>
     public DateOnly Submitted {get; set;} = submitted;
@@ -69,9 +83,11 @@ public class PrintingProjectDto(
     /// </returns>
     public override string ToString()
     {
-        var model     = ModelDesign?.Summary ?? "<no model>";
-        var customer  = Customer?.Name       ?? "<no customer>";
-        var filaments = Filaments.OrderBy(f => f.Manufacturer.Name).ThenBy(f1 => f1.FilamentType.Description).ThenBy(f2 => f2.FilamentColour.Description).ToList();
+        var model    = ModelDesign?.Summary ?? "<no model>";
+        var customer = Customer?.Name       ?? "<no customer>";
+        var filaments =
+            Filaments.OrderBy(f => f.Manufacturer.Name).ThenBy(f1 => f1.FilamentType.Description).ThenBy(f2 => f2.FilamentColour.Description).ToList();
+
         return $"{model} for {customer} {string.Join("/", filaments)}";
     }
 }

--- a/src/gCodeJournal.ViewModel/ExtensionMethods.cs
+++ b/src/gCodeJournal.ViewModel/ExtensionMethods.cs
@@ -1,36 +1,52 @@
-﻿using gCodeJournal.ViewModel.DTOs;
+﻿// gCodeJournal.ViewModel
 
 namespace gCodeJournal.ViewModel;
 
+#region Using Directives
+using DTOs;
+#endregion
+
 public static class ExtensionMethods
 {
-    private static bool IdSequencesEqual<T, TId>(IEnumerable<T>? a, IEnumerable<T>? b, Func<T, TId> idSelector)
-    {
-        if (ReferenceEquals(a, b))
-            return true;
-        if (a is null || b is null)
-            return false;
-        return a.Select(idSelector).SequenceEqual(b.Select(idSelector));
-    }
-
     public static DtoCompareResult CompareTo(this FilamentDto filamentDto, FilamentDto other)
     {
         var errors = new List<string>();
 
         if (filamentDto.Id != other.Id)
+        {
             errors.Add(nameof(filamentDto.Id));
+        }
+
         if (filamentDto.ProductId != other.ProductId)
+        {
             errors.Add(nameof(filamentDto.ProductId));
+        }
+
         if (filamentDto.Manufacturer.Id != other.Manufacturer.Id)
+        {
             errors.Add("ManufacturerId");
+        }
+
         if (filamentDto.CostPerWeight != other.CostPerWeight)
+        {
             errors.Add(nameof(filamentDto.CostPerWeight));
+        }
+
         if (filamentDto.FilamentColour.Id != other.FilamentColour.Id)
+        {
             errors.Add("FilamentColourId");
+        }
+
         if (filamentDto.FilamentType.Id != other.FilamentType.Id)
+        {
             errors.Add("FilamentTypeId");
+        }
+
         if (filamentDto.ReorderLink != other.ReorderLink)
+        {
             errors.Add(nameof(filamentDto.ReorderLink));
+        }
+
         return new DtoCompareResult(errors.Count == 0, errors);
     }
 
@@ -38,9 +54,15 @@ public static class ExtensionMethods
     {
         var errors = new List<string>();
         if (manufacturerDto.Id != other.Id)
+        {
             errors.Add(nameof(manufacturerDto.Id));
+        }
+
         if (manufacturerDto.Name != other.Name)
+        {
             errors.Add(nameof(manufacturerDto.Name));
+        }
+
         return new DtoCompareResult(errors.Count == 0, errors);
     }
 
@@ -48,15 +70,53 @@ public static class ExtensionMethods
     {
         var errors = new List<string>();
         if (modelDesignDto.Id != other.Id)
+        {
             errors.Add(nameof(modelDesignDto.Id));
+        }
+
         if (modelDesignDto.Description != other.Description)
+        {
             errors.Add(nameof(modelDesignDto.Description));
+        }
+
         if (modelDesignDto.Length != other.Length)
+        {
             errors.Add(nameof(modelDesignDto.Length));
+        }
+
         if (modelDesignDto.Summary != other.Summary)
+        {
             errors.Add(nameof(modelDesignDto.Summary));
+        }
+
         if (modelDesignDto.Url != other.Url)
+        {
             errors.Add(nameof(modelDesignDto.Url));
+        }
+
+        return new DtoCompareResult(errors.Count == 0, errors);
+    }
+
+    public static DtoCompareResult CompareTo(this PrinterDto printerDto, PrinterDto other)
+    {
+        ArgumentNullException.ThrowIfNull(printerDto.Manufacturer, nameof(printerDto.Manufacturer));
+        ArgumentNullException.ThrowIfNull(other.Manufacturer,      nameof(other.Manufacturer));
+        var errors = new List<string>();
+        if (printerDto.Id != other.Id)
+        {
+            errors.Add(nameof(printerDto.Id));
+        }
+
+        if (printerDto.Manufacturer.Id != other.Manufacturer.Id)
+        {
+            errors.Add("ManufacturerId");
+        }
+
+        if (printerDto.Model != other.Model)
+        {
+            errors.Add(nameof(printerDto.Model));
+        }
+
         return new DtoCompareResult(errors.Count == 0, errors);
     }
 
@@ -64,17 +124,34 @@ public static class ExtensionMethods
     {
         var errors = new List<string>();
         if (printingProjectDto.Id != other.Id)
+        {
             errors.Add(nameof(printingProjectDto.Id));
+        }
+
         if (printingProjectDto.Completed != other.Completed)
+        {
             errors.Add(nameof(printingProjectDto.Completed));
+        }
+
         if (printingProjectDto.Customer?.Id != other.Customer?.Id)
+        {
             errors.Add("CustomerId");
+        }
+
         if (printingProjectDto.ModelDesign?.Id != other.ModelDesign?.Id)
+        {
             errors.Add("ModelDesignId");
+        }
+
         if (printingProjectDto.Submitted != other.Submitted)
+        {
             errors.Add(nameof(printingProjectDto.Submitted));
+        }
+
         if (!IdSequencesEqual(printingProjectDto.Filaments, other.Filaments, x => x.Id))
+        {
             errors.Add(nameof(printingProjectDto.Filaments));
+        }
 
         return new DtoCompareResult(errors.Count == 0, errors);
     }
@@ -82,24 +159,63 @@ public static class ExtensionMethods
     public static DtoCompareResult CompareTo(this FilamentColourDto filamentColourDto, FilamentColourDto other)
     {
         var errors = new List<string>();
-        if (filamentColourDto.Id != other.Id) errors.Add(nameof(filamentColourDto.Id));
-        if (filamentColourDto.Description != other.Description) errors.Add(nameof(filamentColourDto.Description));
+        if (filamentColourDto.Id != other.Id)
+        {
+            errors.Add(nameof(filamentColourDto.Id));
+        }
+
+        if (filamentColourDto.Description != other.Description)
+        {
+            errors.Add(nameof(filamentColourDto.Description));
+        }
+
         return new DtoCompareResult(errors.Count == 0, errors);
     }
 
     public static DtoCompareResult CompareTo(this FilamentTypeDto filamentTypeDto, FilamentTypeDto other)
     {
         var errors = new List<string>();
-        if (filamentTypeDto.Id != other.Id) errors.Add(nameof(filamentTypeDto.Id));
-        if (filamentTypeDto.Description != other.Description) errors.Add(nameof(filamentTypeDto.Description));
+        if (filamentTypeDto.Id != other.Id)
+        {
+            errors.Add(nameof(filamentTypeDto.Id));
+        }
+
+        if (filamentTypeDto.Description != other.Description)
+        {
+            errors.Add(nameof(filamentTypeDto.Description));
+        }
+
         return new DtoCompareResult(errors.Count == 0, errors);
     }
 
     public static DtoCompareResult CompareTo(this CustomerDto customerDto, CustomerDto other)
     {
         var errors = new List<string>();
-        if (customerDto.Id != other.Id) errors.Add(nameof(customerDto.Id));
-        if (customerDto.Name != other.Name) errors.Add(nameof(customerDto.Name));
+        if (customerDto.Id != other.Id)
+        {
+            errors.Add(nameof(customerDto.Id));
+        }
+
+        if (customerDto.Name != other.Name)
+        {
+            errors.Add(nameof(customerDto.Name));
+        }
+
         return new DtoCompareResult(errors.Count == 0, errors);
+    }
+
+    static bool IdSequencesEqual<T, TId>(IEnumerable<T>? a, IEnumerable<T>? b, Func<T, TId> idSelector)
+    {
+        if (ReferenceEquals(a, b))
+        {
+            return true;
+        }
+
+        if (a is null || b is null)
+        {
+            return false;
+        }
+
+        return a.Select(idSelector).SequenceEqual(b.Select(idSelector));
     }
 }

--- a/src/gCodeJournal.ViewModel/GCodeJournalViewModel.cs
+++ b/src/gCodeJournal.ViewModel/GCodeJournalViewModel.cs
@@ -595,9 +595,9 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
             return new ValidationResult("Printer not found");
         }
 
-        existing.Model        = printerDto.Model;
-        existing.Manufacturer = printerDto.Manufacturer!.ToEntity();
-        existing.CostPerHour  = printerDto.CostPerHour;
+        existing.Model          = printerDto.Model;
+        existing.ManufacturerId = printerDto.Manufacturer!.Id;
+        existing.CostPerHour    = printerDto.CostPerHour;
         await _db.SaveChangesAsync().ConfigureAwait(false);
 
         return ValidationResult.Success;
@@ -742,7 +742,8 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
                                                                    .ToListAsync();
 
     /// <inheritdoc />
-    public Task<List<PrinterDto>> GetAllPrintersAsync() => _db.Printers.OrderBy(p => p).Select(p => new PrinterDto(p)).ToListAsync();
+    public Task<List<PrinterDto>> GetAllPrintersAsync() =>
+        _db.Printers.Include(p => p.Manufacturer).OrderBy(p => p.Manufacturer.Name).ThenBy(p => p.Model).Select(p => new PrinterDto(p)).ToListAsync();
 
     /// <inheritdoc />
     public Task<List<PrintingProjectDto>> GetAllPrintingProjectsAsync() =>
@@ -1272,6 +1273,39 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
         }
 
         _db.ModelDesigns.Remove(existing);
+        await _db.SaveChangesAsync().ConfigureAwait(false);
+
+        return ValidationResult.Success;
+    }
+
+    /// <inheritdoc />
+    public async Task<ValidationResult> DeletePrinterAsync(PrinterDto printerDto)
+    {
+        var validation = ValidatePrinterDto(printerDto);
+        if (validation != ValidationResult.Success)
+        {
+            return validation;
+        }
+
+        if (printerDto.Id == 0)
+        {
+            return new ValidationResult("Printer Id is required for deletion");
+        }
+
+        var existing = await _db.Printers.FindAsync(printerDto.Id).ConfigureAwait(false);
+        if (existing == null)
+        {
+            return new ValidationResult("Printer not found");
+        }
+
+        // Prevent deletion if in use
+        var inUse = await _db.PrintingProjects.AnyAsync(p => p.Printer.Id == existing.Id).ConfigureAwait(false);
+        if (inUse)
+        {
+            return new ValidationResult("Printer is linked to existing projects and cannot be deleted");
+        }
+
+        _db.Printers.Remove(existing);
         await _db.SaveChangesAsync().ConfigureAwait(false);
 
         return ValidationResult.Success;

--- a/src/gCodeJournal.ViewModel/GCodeJournalViewModel.cs
+++ b/src/gCodeJournal.ViewModel/GCodeJournalViewModel.cs
@@ -243,6 +243,28 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
     }
 
     /// <inheritdoc />
+    public async Task<DbUpdateResult> AddPrinterAsync(PrinterDto printerDto)
+    {
+        var validation = ValidatePrinterDto(printerDto);
+        if (validation != ValidationResult.Success)
+        {
+            return new DbUpdateResult(validation, AddRecordResult.Failed);
+        }
+
+        var printer = await GetOrCreatePrinterAsync(printerDto).ConfigureAwait(false);
+
+        // Assume printer already exists
+        var result = AddRecordResult.Exists;
+        if (printer.Id == 0)
+        {
+            await _db.SaveChangesAsync().ConfigureAwait(false);
+            result = AddRecordResult.Added;
+        }
+
+        return new DbUpdateResult(ValidationResult.Success, result);
+    }
+
+    /// <inheritdoc />
     public async Task AddPrintingProjectAsync(PrintingProject project)
     {
         ArgumentNullException.ThrowIfNull(project);
@@ -279,6 +301,9 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
             model = await GetOrCreateModelDesignAsync(projectDto.ModelDesign).ConfigureAwait(false);
         }
 
+        // Resolve or create Printer
+        var printer = await GetOrCreatePrinterAsync(projectDto.Printer!).ConfigureAwait(false);
+
         // Create project entity and attach resolved relations
         var filaments = new List<Filament>();
         if (projectDto.Filaments != null)
@@ -302,9 +327,10 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
                         var typ = await GetOrCreateFilamentTypeAsync(fDto.FilamentType).ConfigureAwait(false);
                         var col = await GetOrCreateFilamentColourAsync(fDto.FilamentColour).ConfigureAwait(false);
 
-                        var existingFilament = await _db.Filaments.FirstOrDefaultAsync(
-                                x => x.ManufacturerId == man.Id && x.FilamentTypeId == typ.Id && x.FilamentColourId == col.Id)
-                            .ConfigureAwait(false);
+                        var existingFilament =
+                            await _db
+                                  .Filaments.FirstOrDefaultAsync(x => x.ManufacturerId == man.Id && x.FilamentTypeId == typ.Id && x.FilamentColourId == col.Id)
+                                  .ConfigureAwait(false);
 
                         if (existingFilament != null)
                         {
@@ -361,6 +387,7 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
                 Completed = projectDto.Completed?.ToDateTime(TimeOnly.MinValue),
                 Customer  = customer!,
                 Model     = model!,
+                Printer   = printer,
                 Filaments = filaments
             };
 
@@ -548,6 +575,34 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
         return ValidationResult.Success;
     }
 
+    /// <inheritdoc />
+    public async Task<ValidationResult> EditPrinterAsync(PrinterDto printerDto)
+    {
+        var validation = ValidatePrinterDto(printerDto);
+        if (validation != ValidationResult.Success)
+        {
+            return validation;
+        }
+
+        if (printerDto.Id == 0)
+        {
+            return new ValidationResult("Printer Id is required for editing");
+        }
+
+        var existing = await _db.Printers.FindAsync(printerDto.Id).ConfigureAwait(false);
+        if (existing == null)
+        {
+            return new ValidationResult("Printer not found");
+        }
+
+        existing.Model        = printerDto.Model;
+        existing.Manufacturer = printerDto.Manufacturer!.ToEntity();
+        existing.CostPerHour  = printerDto.CostPerHour;
+        await _db.SaveChangesAsync().ConfigureAwait(false);
+
+        return ValidationResult.Success;
+    }
+
     public async Task<ValidationResult> EditPrintingProjectAsync(PrintingProjectDto printingProjectDto)
     {
         var validation = ValidatePrintingProjectDto(printingProjectDto);
@@ -687,6 +742,9 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
                                                                    .ToListAsync();
 
     /// <inheritdoc />
+    public Task<List<PrinterDto>> GetAllPrintersAsync() => _db.Printers.OrderBy(p => p.ToString()).Select(p => new PrinterDto(p)).ToListAsync();
+
+    /// <inheritdoc />
     public Task<List<PrintingProjectDto>> GetAllPrintingProjectsAsync() =>
         _db
             .PrintingProjects.Include(p => p.Customer)
@@ -697,6 +755,8 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
             .ThenInclude(f => f.Colour)
             .Include(p => p.Filaments)
             .ThenInclude(f => f.Type)
+            .Include(p => p.Printer)
+            .ThenInclude(p => p.Manufacturer)
             .Select(p =>
                         new PrintingProjectDto(
                             p.Id,
@@ -705,6 +765,7 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
                             p.Completed == null ? null : DateOnly.FromDateTime(p.Completed.Value),
                             p.Customer  == null ? null : new CustomerDto(p.Customer.Id, p.Customer.Name),
                             p.Model     == null ? null : new ModelDesignDto(p.Model.Id, p.Model.Description, p.Model.Length, p.Model.Summary, p.Model.Url),
+                            p.Printer   == null ? null : new PrinterDto(p.Printer),
                             p
                                 .Filaments.Select(f =>
                                                       new FilamentDto(
@@ -788,6 +849,14 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
     }
 
     /// <inheritdoc />
+    public async Task<PrinterDto?> GetPrinterAsync(int id)
+    {
+        var p = await _db.Printers.FindAsync(id).ConfigureAwait(false);
+
+        return p == null ? null : new PrinterDto(p);
+    }
+
+    /// <inheritdoc />
     public async Task<PrintingProjectDto?> GetPrintingProjectAsync(int id)
     {
         var p =
@@ -828,6 +897,7 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
             p.Completed == null ? null : DateOnly.FromDateTime(p.Completed.Value),
             p.Customer  == null ? null : new CustomerDto(p.Customer.Id, p.Customer.Name),
             p.Model     == null ? null : new ModelDesignDto(p.Model.Id, p.Model.Description, p.Model.Length, p.Model.Summary, p.Model.Url),
+            p.Printer   == null ? null : new PrinterDto(p.Printer),
             filaments);
     }
 
@@ -927,6 +997,26 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
         return dto.Length < 0 ? new ValidationResult("ModelDesign length must be non-negative", [nameof(dto.Length)]) : ValidationResult.Success!;
     }
 
+    static ValidationResult ValidatePrinterDto(PrinterDto dto)
+    {
+        if (dto is null)
+        {
+            return new ValidationResult("Printer DTO is required");
+        }
+
+        if (string.IsNullOrWhiteSpace(dto.Model))
+        {
+            return new ValidationResult("Printer model is required", [nameof(dto.Model)]);
+        }
+
+        if (dto.Manufacturer is null)
+        {
+            return new ValidationResult("Printer manufacturer is required", [nameof(dto.Manufacturer)]);
+        }
+
+        return ValidationResult.Success!;
+    }
+
     static ValidationResult ValidateFilamentDto(FilamentDto dto)
     {
         if (dto is null)
@@ -979,6 +1069,11 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
         if (dto.ModelDesign is null)
         {
             errors.Add(new ValidationResult("Printing project must have a model design", [nameof(dto.ModelDesign)]));
+        }
+
+        if (dto.Printer is null)
+        {
+            errors.Add(new ValidationResult("Printing project must have a printer", [nameof(dto.Printer)]));
         }
 
         return errors.Count > 0 ? new ValidationResult(string.Join("; ", errors.Select(e => e.ErrorMessage))) : ValidationResult.Success!;
@@ -1275,6 +1370,7 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
     async Task<Customer> GetOrCreateCustomerAsync(CustomerDto dto)
     {
         ArgumentNullException.ThrowIfNull(dto);
+
         // Prefer matching by name. If a name is supplied, use case-insensitive lookup
         // and return existing customer or create a new one with that name.
         if (!string.IsNullOrWhiteSpace(dto.Name))
@@ -1288,6 +1384,7 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
             var created = dto.ToEntity();
             created.Id = 0;
             await _db.Customers.AddAsync(created).ConfigureAwait(false);
+
             return created;
         }
 
@@ -1305,6 +1402,7 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
         var fallback = dto.ToEntity();
         fallback.Id = 0;
         await _db.Customers.AddAsync(fallback).ConfigureAwait(false);
+
         return fallback;
     }
 
@@ -1326,6 +1424,39 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
         var created = dto.ToEntity();
         created.Id = 0;
         await _db.ModelDesigns.AddAsync(created).ConfigureAwait(false);
+
+        return created;
+    }
+
+    async Task<Printer> GetOrCreatePrinterAsync(PrinterDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+        ArgumentNullException.ThrowIfNull(dto.Manufacturer);
+        ArgumentNullException.ThrowIfNullOrWhiteSpace(dto.Manufacturer.Name);
+        Printer? existing = null;
+        if (dto.Id != 0)
+        {
+            existing = await _db.Printers.FindAsync(dto.Id).ConfigureAwait(false);
+        }
+
+        existing ??=
+            await _db
+                  .Printers.FirstOrDefaultAsync(p =>
+                                                    EF.Functions.Collate(p.Model,                "NOCASE") == dto.Model
+                                                    && EF.Functions.Collate(p.Manufacturer.Name, "NOCASE") == dto.Manufacturer.Name)
+                  .ConfigureAwait(false);
+        if (existing != null)
+        {
+            return existing;
+        }
+
+        // Get or create the manufacturer first to ensure referential integrity, then create printer referencing that manufacturer
+        var manufacturer = await GetOrCreateManufacturerAsync(dto.Manufacturer).ConfigureAwait(false);
+        dto.Manufacturer = new ManufacturerDto(manufacturer);
+
+        var created = dto.ToEntity();
+        created.Id = 0;
+        await _db.Printers.AddAsync(created).ConfigureAwait(false);
 
         return created;
     }

--- a/src/gCodeJournal.ViewModel/GCodeJournalViewModel.cs
+++ b/src/gCodeJournal.ViewModel/GCodeJournalViewModel.cs
@@ -742,7 +742,7 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
                                                                    .ToListAsync();
 
     /// <inheritdoc />
-    public Task<List<PrinterDto>> GetAllPrintersAsync() => _db.Printers.OrderBy(p => p.ToString()).Select(p => new PrinterDto(p)).ToListAsync();
+    public Task<List<PrinterDto>> GetAllPrintersAsync() => _db.Printers.OrderBy(p => p).Select(p => new PrinterDto(p)).ToListAsync();
 
     /// <inheritdoc />
     public Task<List<PrintingProjectDto>> GetAllPrintingProjectsAsync() =>

--- a/src/gCodeJournal.ViewModel/GCodeJournalViewModel.cs
+++ b/src/gCodeJournal.ViewModel/GCodeJournalViewModel.cs
@@ -281,7 +281,7 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
             return new DbUpdateResult(validation, AddRecordResult.Failed);
         }
 
-        var existing = await GetPrintingProjectAsync(projectDto.Id).ConfigureAwait(false);
+        var existing = await GetPrintingProjectAsync(projectDto).ConfigureAwait(false);
         if (existing is not null)
         {
             return new DbUpdateResult(ValidationResult.Success, AddRecordResult.Exists);
@@ -724,7 +724,7 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
                             f.ReorderLink,
                             new FilamentColourDto(f.Colour.Id, f.Colour.Description),
                             new FilamentTypeDto(f.Type.Id, f.Type.Description),
-                            new ManufacturerDto(f.Manufacturer.Id, f.Manufacturer.Name)))
+                            new ManufacturerDto(f.Manufacturer)))
             .ToListAsync();
 
     /// <inheritdoc />
@@ -733,7 +733,7 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
 
     /// <inheritdoc />
     public Task<List<ManufacturerDto>> GetAllManufacturersAsync() =>
-        _db.Manufacturers.OrderBy(m => m.Name).Select(m => new ManufacturerDto(m.Id, m.Name)).ToListAsync();
+        _db.Manufacturers.OrderBy(m => m.Name).Select(m => new ManufacturerDto(m)).ToListAsync();
 
     /// <inheritdoc />
     public Task<List<ModelDesignDto>> GetAllModelDesignsAsync() => _db
@@ -775,7 +775,7 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
                                                           f.ReorderLink,
                                                           new FilamentColourDto(f.Colour.Id, f.Colour.Description),
                                                           new FilamentTypeDto(f.Type.Id, f.Type.Description),
-                                                          new ManufacturerDto(f.Manufacturer.Id, f.Manufacturer.Name)))
+                                                          new ManufacturerDto(f.Manufacturer)))
                                 .ToList()))
             .ToListAsync();
 
@@ -936,6 +936,26 @@ public class GCodeJournalViewModel : IGCodeJournalViewModel
         }
     }
     #endregion
+
+    public static PrintingProjectDto? GetPrintingProjectAsync(List<PrintingProjectDto> projects, PrintingProjectDto dto) =>
+        projects.FirstOrDefault(p =>
+                                    p.Customer?.Name                 == dto.Customer?.Name
+                                    && p.ModelDesign?.Summary        == dto.ModelDesign?.Summary
+                                    && p.Printer?.Manufacturer?.Name == dto.Printer?.Manufacturer?.Name
+                                    && p.Printer?.Model              == dto.Printer?.Model
+                                    && p.Submitted                   == dto.Submitted);
+
+    public async Task<PrintingProjectDto?> GetPrintingProjectAsync(PrintingProjectDto dto) => GetPrintingProjectAsync(await GetAllPrintingProjectsAsync(), dto);
+
+    IQueryable<PrintingProject> GetPrintingProjects() => _db
+                                                         .PrintingProjects.Include(pr => pr.Customer)
+                                                         .Include(pr => pr.Model)
+                                                         .Include(pr => pr.Filaments)
+                                                         .ThenInclude(f => f.Manufacturer)
+                                                         .Include(pr => pr.Filaments)
+                                                         .ThenInclude(f => f.Colour)
+                                                         .Include(pr => pr.Filaments)
+                                                         .ThenInclude(f => f.Type);
 
     #region Validation helpers
     static ValidationResult ValidateCustomerDto(CustomerDto dto)

--- a/src/gCodeJournal.ViewModel/IGCodeJournalViewModel.cs
+++ b/src/gCodeJournal.ViewModel/IGCodeJournalViewModel.cs
@@ -1,381 +1,417 @@
-namespace gCodeJournal.ViewModel
+// gCodeJournal.ViewModel
+
+namespace gCodeJournal.ViewModel;
+
+#region Using Directives
+using System.ComponentModel.DataAnnotations;
+using DTOs;
+using Import;
+using Microsoft.Extensions.Logging;
+using Model;
+#endregion
+
+/// <summary>
+///     Represents the view model interface for managing GCode Journal operations.
+///     Provides methods to add and retrieve data related to customers, filaments, filament colors, filament types, model
+///     designs, and printing projects.
+/// </summary>
+public interface IGCodeJournalViewModel
 {
-    #region Using Directives
-    using System.ComponentModel.DataAnnotations;
-    using DTOs;
-    using Import;
-    using Microsoft.Extensions.Logging;
-    using Model;
-    #endregion
+    // Add operations (entity-based)
+    /// <summary>
+    ///     Adds a new customer asynchronously.
+    /// </summary>
+    /// <param name="customer">The customer to add.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task AddCustomerAsync(Customer customer);
+
+    // Add operations (DTO-based overloads) - return ValidationResult instead of throwing
+    /// <summary>
+    ///     Adds a new customer asynchronously using DTO.
+    /// </summary>
+    /// <param name="customerDto">The customer DTO to add.</param>
+    /// <returns>
+    ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
+    ///     errors.
+    /// </returns>
+    Task<DbUpdateResult> AddCustomerAsync(CustomerDto customerDto);
 
     /// <summary>
-    ///     Represents the view model interface for managing GCode Journal operations.
-    ///     Provides methods to add and retrieve data related to customers, filaments, filament colors, filament types, model
-    ///     designs, and printing projects.
+    ///     Adds a new filament asynchronously.
     /// </summary>
-    public interface IGCodeJournalViewModel
-    {
-        // Add operations (entity-based)
-        /// <summary>
-        ///     Adds a new customer asynchronously.
-        /// </summary>
-        /// <param name="customer">The customer to add.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        Task AddCustomerAsync(Customer customer);
+    /// <param name="filament">The filament to add.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task AddFilamentAsync(Filament filament);
 
-        // Add operations (DTO-based overloads) - return ValidationResult instead of throwing
-        /// <summary>
-        ///     Adds a new customer asynchronously using DTO.
-        /// </summary>
-        /// <param name="customerDto">The customer DTO to add.</param>
-        /// <returns>
-        ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
-        ///     errors.
-        /// </returns>
-        Task<DbUpdateResult> AddCustomerAsync(CustomerDto customerDto);
+    /// <summary>
+    ///     Adds a new filament asynchronously using DTO.
+    /// </summary>
+    /// <param name="filamentDto">The filament DTO to add.</param>
+    /// <returns>
+    ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
+    ///     errors.
+    /// </returns>
+    Task<DbUpdateResult> AddFilamentAsync(FilamentDto filamentDto);
 
-        /// <summary>
-        ///     Adds a new filament asynchronously.
-        /// </summary>
-        /// <param name="filament">The filament to add.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        Task AddFilamentAsync(Filament filament);
+    /// <summary>
+    ///     Adds a new filament color asynchronously.
+    /// </summary>
+    /// <param name="filamentColour">The filament color to add.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task AddFilamentColourAsync(FilamentColour filamentColour);
 
-        /// <summary>
-        ///     Adds a new filament asynchronously using DTO.
-        /// </summary>
-        /// <param name="filamentDto">The filament DTO to add.</param>
-        /// <returns>
-        ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
-        ///     errors.
-        /// </returns>
-        Task<DbUpdateResult> AddFilamentAsync(FilamentDto filamentDto);
+    /// <summary>
+    ///     Adds a new filament color asynchronously using DTO.
+    /// </summary>
+    /// <param name="filamentColourDto">The filament color DTO to add.</param>
+    /// <returns>
+    ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
+    ///     errors.
+    /// </returns>
+    Task<DbUpdateResult> AddFilamentColourAsync(FilamentColourDto filamentColourDto);
 
-        /// <summary>
-        ///     Adds a new filament color asynchronously.
-        /// </summary>
-        /// <param name="filamentColour">The filament color to add.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        Task AddFilamentColourAsync(FilamentColour filamentColour);
+    /// <summary>
+    ///     Adds a new filament type asynchronously.
+    /// </summary>
+    /// <param name="filamentType">The filament type to add.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task AddFilamentTypeAsync(FilamentType filamentType);
 
-        /// <summary>
-        ///     Adds a new filament color asynchronously using DTO.
-        /// </summary>
-        /// <param name="filamentColourDto">The filament color DTO to add.</param>
-        /// <returns>
-        ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
-        ///     errors.
-        /// </returns>
-        Task<DbUpdateResult> AddFilamentColourAsync(FilamentColourDto filamentColourDto);
+    /// <summary>
+    ///     Adds a new filament type asynchronously using DTO.
+    /// </summary>
+    /// <param name="filamentTypeDto">The filament type DTO to add.</param>
+    /// <returns>
+    ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
+    ///     errors.
+    /// </returns>
+    Task<DbUpdateResult> AddFilamentTypeAsync(FilamentTypeDto filamentTypeDto);
 
-        /// <summary>
-        ///     Adds a new filament type asynchronously.
-        /// </summary>
-        /// <param name="filamentType">The filament type to add.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        Task AddFilamentTypeAsync(FilamentType filamentType);
+    /// <summary>
+    ///     Adds a new manufacturer asynchronously.
+    /// </summary>
+    /// <param name="manufacturer">The manufacturer entity to add.</param>
+    /// <remarks>
+    ///     The <paramref name="manufacturer" /> represents a vendor or brand of 3D printing filament.
+    ///     Typical examples include "Prusament" or "Hatchbox".
+    /// </remarks>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="manufacturer" /> is <c>null</c>.</exception>
+    Task AddManufacturerAsync(Manufacturer manufacturer);
 
-        /// <summary>
-        ///     Adds a new filament type asynchronously using DTO.
-        /// </summary>
-        /// <param name="filamentTypeDto">The filament type DTO to add.</param>
-        /// <returns>
-        ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
-        ///     errors.
-        /// </returns>
-        Task<DbUpdateResult> AddFilamentTypeAsync(FilamentTypeDto filamentTypeDto);
+    /// <summary>
+    ///     Adds a new manufacturer asynchronously using a DTO.
+    /// </summary>
+    /// <param name="manufacturer">The manufacturer DTO to add.</param>
+    /// <returns>
+    ///     A task representing the asynchronous operation; returns a <see cref="ValidationResult" /> indicating success or
+    ///     validation errors.
+    /// </returns>
+    Task<DbUpdateResult> AddManufacturerAsync(ManufacturerDto manufacturer);
 
-        /// <summary>
-        ///     Adds a new manufacturer asynchronously.
-        /// </summary>
-        /// <param name="manufacturer">The manufacturer entity to add.</param>
-        /// <remarks>
-        ///     The <paramref name="manufacturer" /> represents a vendor or brand of 3D printing filament.
-        ///     Typical examples include "Prusament" or "Hatchbox".
-        /// </remarks>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="manufacturer" /> is <c>null</c>.</exception>
-        Task AddManufacturerAsync(Manufacturer manufacturer);
+    /// <summary>
+    ///     Adds a new model design asynchronously.
+    /// </summary>
+    /// <param name="modelDesign">The model design to add.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task AddModelDesignAsync(ModelDesign modelDesign);
 
-        /// <summary>
-        ///     Adds a new manufacturer asynchronously using a DTO.
-        /// </summary>
-        /// <param name="manufacturer">The manufacturer DTO to add.</param>
-        /// <returns>
-        ///     A task representing the asynchronous operation; returns a <see cref="ValidationResult" /> indicating success or
-        ///     validation errors.
-        /// </returns>
-        Task<DbUpdateResult> AddManufacturerAsync(ManufacturerDto manufacturer);
+    /// <summary>
+    ///     Adds a new model design asynchronously using DTO.
+    /// </summary>
+    /// <param name="modelDesignDto">The model design DTO to add.</param>
+    /// <returns>
+    ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
+    ///     errors.
+    /// </returns>
+    Task<DbUpdateResult> AddModelDesignAsync(ModelDesignDto modelDesignDto);
 
-        /// <summary>
-        ///     Adds a new model design asynchronously.
-        /// </summary>
-        /// <param name="modelDesign">The model design to add.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        Task AddModelDesignAsync(ModelDesign modelDesign);
+    /// <summary>
+    ///     Adds a new printer to the system asynchronously.
+    /// </summary>
+    /// <param name="printerDto">
+    ///     The data transfer object containing the details of the printer to be added.
+    /// </param>
+    /// <returns>
+    ///     A <see cref="Task{TResult}" /> representing the asynchronous operation,
+    ///     with a <see cref="DbUpdateResult" /> indicating the result of the operation.
+    /// </returns>
+    Task<DbUpdateResult> AddPrinterAsync(PrinterDto printerDto);
 
-        /// <summary>
-        ///     Adds a new model design asynchronously using DTO.
-        /// </summary>
-        /// <param name="modelDesignDto">The model design DTO to add.</param>
-        /// <returns>
-        ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
-        ///     errors.
-        /// </returns>
-        Task<DbUpdateResult> AddModelDesignAsync(ModelDesignDto modelDesignDto);
+    /// <summary>
+    ///     Adds a new printing project asynchronously.
+    /// </summary>
+    /// <param name="project">The printing project to add.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task AddPrintingProjectAsync(PrintingProject project);
 
-        /// <summary>
-        ///     Adds a new printing project asynchronously.
-        /// </summary>
-        /// <param name="project">The printing project to add.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
-        Task AddPrintingProjectAsync(PrintingProject project);
+    /// <summary>
+    ///     Adds a new printing project asynchronously using DTO.
+    /// </summary>
+    /// <param name="projectDto">The printing project DTO to add.</param>
+    /// <returns>
+    ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
+    ///     errors.
+    /// </returns>
+    Task<DbUpdateResult> AddPrintingProjectAsync(PrintingProjectDto projectDto);
 
-        /// <summary>
-        ///     Adds a new printing project asynchronously using DTO.
-        /// </summary>
-        /// <param name="projectDto">The printing project DTO to add.</param>
-        /// <returns>
-        ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
-        ///     errors.
-        /// </returns>
-        Task<DbUpdateResult> AddPrintingProjectAsync(PrintingProjectDto projectDto);
+    // Delete operations (DTO-based)
+    /// <summary>
+    ///     Deletes the specified customer represented by a DTO.
+    /// </summary>
+    Task<ValidationResult> DeleteCustomerAsync(CustomerDto customerDto);
 
-        // Delete operations (DTO-based)
-        /// <summary>
-        ///     Deletes the specified customer represented by a DTO.
-        /// </summary>
-        Task<ValidationResult> DeleteCustomerAsync(CustomerDto customerDto);
+    /// <summary>
+    ///     Deletes the specified filament represented by a DTO.
+    /// </summary>
+    Task<ValidationResult> DeleteFilamentAsync(FilamentDto filamentDto);
 
-        /// <summary>
-        ///     Deletes the specified filament represented by a DTO.
-        /// </summary>
-        Task<ValidationResult> DeleteFilamentAsync(FilamentDto filamentDto);
+    /// <summary>
+    ///     Deletes the specified filament colour represented by a DTO.
+    /// </summary>
+    Task<ValidationResult> DeleteFilamentColourAsync(FilamentColourDto filamentColourDto);
 
-        /// <summary>
-        ///     Deletes the specified filament colour represented by a DTO.
-        /// </summary>
-        Task<ValidationResult> DeleteFilamentColourAsync(FilamentColourDto filamentColourDto);
+    /// <summary>
+    ///     Deletes the specified filament type represented by a DTO.
+    /// </summary>
+    Task<ValidationResult> DeleteFilamentTypeAsync(FilamentTypeDto filamentTypeDto);
 
-        /// <summary>
-        ///     Deletes the specified filament type represented by a DTO.
-        /// </summary>
-        Task<ValidationResult> DeleteFilamentTypeAsync(FilamentTypeDto filamentTypeDto);
+    /// <summary>
+    ///     Deletes the specified manufacturer represented by a DTO.
+    /// </summary>
+    Task<ValidationResult> DeleteManufacturerAsync(ManufacturerDto manufacturerDto);
 
-        /// <summary>
-        ///     Deletes the specified manufacturer represented by a DTO.
-        /// </summary>
-        Task<ValidationResult> DeleteManufacturerAsync(ManufacturerDto manufacturerDto);
+    /// <summary>
+    ///     Deletes the specified model design represented by a DTO.
+    /// </summary>
+    Task<ValidationResult> DeleteModelDesignAsync(ModelDesignDto modelDesignDto);
 
-        /// <summary>
-        ///     Deletes the specified model design represented by a DTO.
-        /// </summary>
-        Task<ValidationResult> DeleteModelDesignAsync(ModelDesignDto modelDesignDto);
+    /// <summary>
+    ///     Deletes the specified printing project represented by a DTO.
+    /// </summary>
+    Task<ValidationResult> DeletePrintingProjectAsync(PrintingProjectDto printingProjectDto);
 
-        /// <summary>
-        ///     Deletes the specified printing project represented by a DTO.
-        /// </summary>
-        Task<ValidationResult> DeletePrintingProjectAsync(PrintingProjectDto printingProjectDto);
+    // Edit operations (DTO-based)
+    /// <summary>
+    ///     Edits an existing customer asynchronously using DTO.
+    /// </summary>
+    /// <param name="customerDto">The customer DTO with updated values.</param>
+    /// <returns>
+    ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
+    ///     errors.
+    /// </returns>
+    Task<ValidationResult> EditCustomerAsync(CustomerDto customerDto);
 
-        // Edit operations (DTO-based)
-        /// <summary>
-        ///     Edits an existing customer asynchronously using DTO.
-        /// </summary>
-        /// <param name="customerDto">The customer DTO with updated values.</param>
-        /// <returns>
-        ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
-        ///     errors.
-        /// </returns>
-        Task<ValidationResult> EditCustomerAsync(CustomerDto customerDto);
+    /// <summary>
+    ///     Edits an existing filament asynchronously using DTO.
+    /// </summary>
+    /// <param name="filamentDto">The filament DTO with updated values.</param>
+    /// <returns>
+    ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
+    ///     errors.
+    /// </returns>
+    Task<ValidationResult> EditFilamentAsync(FilamentDto filamentDto);
 
-        /// <summary>
-        ///     Edits an existing filament asynchronously using DTO.
-        /// </summary>
-        /// <param name="filamentDto">The filament DTO with updated values.</param>
-        /// <returns>
-        ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
-        ///     errors.
-        /// </returns>
-        Task<ValidationResult> EditFilamentAsync(FilamentDto filamentDto);
+    /// <summary>
+    ///     Edits an existing filament color asynchronously using DTO.
+    /// </summary>
+    /// <param name="filamentColourDto">The filament color DTO with updated values.</param>
+    /// <returns>
+    ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
+    ///     errors.
+    /// </returns>
+    Task<ValidationResult> EditFilamentColourAsync(FilamentColourDto filamentColourDto);
 
-        /// <summary>
-        ///     Edits an existing filament color asynchronously using DTO.
-        /// </summary>
-        /// <param name="filamentColourDto">The filament color DTO with updated values.</param>
-        /// <returns>
-        ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
-        ///     errors.
-        /// </returns>
-        Task<ValidationResult> EditFilamentColourAsync(FilamentColourDto filamentColourDto);
+    /// <summary>
+    ///     Edits an existing filament type asynchronously using DTO.
+    /// </summary>
+    /// <param name="filamentTypeDto">The filament type DTO with updated values.</param>
+    /// <returns>
+    ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
+    ///     errors.
+    /// </returns>
+    Task<ValidationResult> EditFilamentTypeAsync(FilamentTypeDto filamentTypeDto);
 
-        /// <summary>
-        ///     Edits an existing filament type asynchronously using DTO.
-        /// </summary>
-        /// <param name="filamentTypeDto">The filament type DTO with updated values.</param>
-        /// <returns>
-        ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
-        ///     errors.
-        /// </returns>
-        Task<ValidationResult> EditFilamentTypeAsync(FilamentTypeDto filamentTypeDto);
+    /// <summary>
+    ///     Edits an existing manufacturer asynchronously using DTO.
+    /// </summary>
+    /// <param name="manufacturerDto">The manufacturer DTO with updated values.</param>
+    /// <returns>
+    ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
+    ///     errors.
+    /// </returns>
+    Task<ValidationResult> EditManufacturerAsync(ManufacturerDto manufacturerDto);
 
-        /// <summary>
-        ///     Edits an existing manufacturer asynchronously using DTO.
-        /// </summary>
-        /// <param name="manufacturerDto">The manufacturer DTO with updated values.</param>
-        /// <returns>
-        ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
-        ///     errors.
-        /// </returns>
-        Task<ValidationResult> EditManufacturerAsync(ManufacturerDto manufacturerDto);
+    /// <summary>
+    ///     Edits an existing model design asynchronously using DTO.
+    /// </summary>
+    /// <param name="modelDesignDto">The model design DTO with updated values.</param>
+    /// <returns>
+    ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
+    ///     errors.
+    /// </returns>
+    Task<ValidationResult> EditModelDesignAsync(ModelDesignDto modelDesignDto);
 
-        /// <summary>
-        ///     Edits an existing model design asynchronously using DTO.
-        /// </summary>
-        /// <param name="modelDesignDto">The model design DTO with updated values.</param>
-        /// <returns>
-        ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
-        ///     errors.
-        /// </returns>
-        Task<ValidationResult> EditModelDesignAsync(ModelDesignDto modelDesignDto);
+    /// <summary>
+    ///     Edits an existing printer asynchronously using DTO.
+    /// </summary>
+    /// <param name="printerDto">The printer DTO with updated values.</param>
+    /// <returns>
+    ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
+    ///     errors.
+    /// </returns>
+    Task<ValidationResult> EditPrinterAsync(PrinterDto printerDto);
 
-        /// <summary>
-        ///     Edits an existing printing project asynchronously using DTO.
-        /// </summary>
-        /// <param name="printingProjectDto">The printing project DTO with updated values.</param>
-        /// <returns>
-        ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
-        ///     errors.
-        /// </returns>
-        Task<ValidationResult> EditPrintingProjectAsync(PrintingProjectDto printingProjectDto);
+    /// <summary>
+    ///     Edits an existing printing project asynchronously using DTO.
+    /// </summary>
+    /// <param name="printingProjectDto">The printing project DTO with updated values.</param>
+    /// <returns>
+    ///     A task representing the asynchronous operation; returns a ValidationResult indicating success or validation
+    ///     errors.
+    /// </returns>
+    Task<ValidationResult> EditPrintingProjectAsync(PrintingProjectDto printingProjectDto);
 
-        // Retrieval operations (DTO-based)
-        /// <summary>
-        ///     Retrieves all customers asynchronously.
-        /// </summary>
-        /// <returns>A task representing the asynchronous operation, with a list of customers as the result.</returns>
-        Task<List<CustomerDto>> GetAllCustomersAsync();
+    // Retrieval operations (DTO-based)
+    /// <summary>
+    ///     Retrieves all customers asynchronously.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation, with a list of customers as the result.</returns>
+    Task<List<CustomerDto>> GetAllCustomersAsync();
 
-        /// <summary>
-        ///     Retrieves all filament colors asynchronously.
-        /// </summary>
-        /// <returns>A task representing the asynchronous operation, with a list of filament colors as the result.</returns>
-        Task<List<FilamentColourDto>> GetAllFilamentColoursAsync();
+    /// <summary>
+    ///     Retrieves all filament colors asynchronously.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation, with a list of filament colors as the result.</returns>
+    Task<List<FilamentColourDto>> GetAllFilamentColoursAsync();
 
-        /// <summary>
-        ///     Retrieves all filaments asynchronously.
-        /// </summary>
-        /// <returns>A task representing the asynchronous operation, with a list of filaments as the result.</returns>
-        Task<List<FilamentDto>> GetAllFilamentsAsync();
+    /// <summary>
+    ///     Retrieves all filaments asynchronously.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation, with a list of filaments as the result.</returns>
+    Task<List<FilamentDto>> GetAllFilamentsAsync();
 
-        /// <summary>
-        ///     Retrieves all filament types asynchronously.
-        /// </summary>
-        /// <returns>A task representing the asynchronous operation, with a list of filament types as the result.</returns>
-        Task<List<FilamentTypeDto>> GetAllFilamentTypesAsync();
+    /// <summary>
+    ///     Retrieves all filament types asynchronously.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation, with a list of filament types as the result.</returns>
+    Task<List<FilamentTypeDto>> GetAllFilamentTypesAsync();
 
-        /// <summary>
-        ///     Retrieves all manufacturers asynchronously.
-        /// </summary>
-        /// <returns>A task representing the asynchronous operation, with a list of manufacturers as the result.</returns>
-        Task<List<ManufacturerDto>> GetAllManufacturersAsync();
+    /// <summary>
+    ///     Retrieves all manufacturers asynchronously.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation, with a list of manufacturers as the result.</returns>
+    Task<List<ManufacturerDto>> GetAllManufacturersAsync();
 
-        /// <summary>
-        ///     Retrieves all model designs asynchronously.
-        /// </summary>
-        /// <returns>A task representing the asynchronous operation, with a list of model designs as the result.</returns>
-        Task<List<ModelDesignDto>> GetAllModelDesignsAsync();
+    /// <summary>
+    ///     Retrieves all model designs asynchronously.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation, with a list of model designs as the result.</returns>
+    Task<List<ModelDesignDto>> GetAllModelDesignsAsync();
 
-        /// <summary>
-        ///     Retrieves all printing projects asynchronously.
-        /// </summary>
-        /// <returns>A task representing the asynchronous operation, with a list of printing projects as the result.</returns>
-        Task<List<PrintingProjectDto>> GetAllPrintingProjectsAsync();
+    /// <summary>
+    ///     Retrieves all printers asynchronously.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation, with a list of printers as the result.</returns>
+    Task<List<PrinterDto>> GetAllPrintersAsync();
 
-        /// <summary>
-        ///     Retrieves a single customer DTO by identifier.
-        /// </summary>
-        /// <param name="id">The customer identifier.</param>
-        /// <returns>A task that returns the matching <see cref="CustomerDto"/> or <c>null</c> if not found.</returns>
-        Task<CustomerDto?> GetCustomerAsync(int id);
+    /// <summary>
+    ///     Retrieves all printing projects asynchronously.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation, with a list of printing projects as the result.</returns>
+    Task<List<PrintingProjectDto>> GetAllPrintingProjectsAsync();
 
-        /// <summary>
-        ///     Retrieves a single filament DTO by identifier.
-        /// </summary>
-        /// <param name="id">The filament identifier.</param>
-        /// <returns>A task that returns the matching <see cref="FilamentDto"/> or <c>null</c> if not found.</returns>
-        Task<FilamentDto?> GetFilamentAsync(int id);
+    /// <summary>
+    ///     Retrieves a single customer DTO by identifier.
+    /// </summary>
+    /// <param name="id">The customer identifier.</param>
+    /// <returns>A task that returns the matching <see cref="CustomerDto" /> or <c>null</c> if not found.</returns>
+    Task<CustomerDto?> GetCustomerAsync(int id);
 
-        /// <summary>
-        ///     Retrieves a single filament colour DTO by identifier.
-        /// </summary>
-        /// <param name="id">The filament colour identifier.</param>
-        /// <returns>A task that returns the matching <see cref="FilamentColourDto"/> or <c>null</c> if not found.</returns>
-        Task<FilamentColourDto?> GetFilamentColourAsync(int id);
+    /// <summary>
+    ///     Retrieves a single filament DTO by identifier.
+    /// </summary>
+    /// <param name="id">The filament identifier.</param>
+    /// <returns>A task that returns the matching <see cref="FilamentDto" /> or <c>null</c> if not found.</returns>
+    Task<FilamentDto?> GetFilamentAsync(int id);
 
-        /// <summary>
-        ///     Retrieves a single filament type DTO by identifier.
-        /// </summary>
-        /// <param name="id">The filament type identifier.</param>
-        /// <returns>A task that returns the matching <see cref="FilamentTypeDto"/> or <c>null</c> if not found.</returns>
-        Task<FilamentTypeDto?> GetFilamentTypeAsync(int id);
+    /// <summary>
+    ///     Retrieves a single filament colour DTO by identifier.
+    /// </summary>
+    /// <param name="id">The filament colour identifier.</param>
+    /// <returns>A task that returns the matching <see cref="FilamentColourDto" /> or <c>null</c> if not found.</returns>
+    Task<FilamentColourDto?> GetFilamentColourAsync(int id);
 
-        /// <summary>
-        ///     Retrieves a single manufacturer DTO by identifier.
-        /// </summary>
-        /// <param name="id">The manufacturer identifier.</param>
-        /// <returns>A task that returns the matching <see cref="ManufacturerDto"/> or <c>null</c> if not found.</returns>
-        Task<ManufacturerDto?> GetManufacturerAsync(int id);
+    /// <summary>
+    ///     Retrieves a single filament type DTO by identifier.
+    /// </summary>
+    /// <param name="id">The filament type identifier.</param>
+    /// <returns>A task that returns the matching <see cref="FilamentTypeDto" /> or <c>null</c> if not found.</returns>
+    Task<FilamentTypeDto?> GetFilamentTypeAsync(int id);
 
-        /// <summary>
-        ///     Retrieves a single model design DTO by identifier.
-        /// </summary>
-        /// <param name="id">The model design identifier.</param>
-        /// <returns>A task that returns the matching <see cref="ModelDesignDto"/> or <c>null</c> if not found.</returns>
-        Task<ModelDesignDto?> GetModelDesignAsync(int id);
+    /// <summary>
+    ///     Retrieves the path of the last imported file, if available.
+    /// </summary>
+    /// <returns>
+    ///     A string representing the path of the last imported file, or <c>null</c> if no import has been performed.
+    /// </returns>
+    string? GetLastImportPath();
 
-        /// <summary>
-        ///     Retrieves a single printing project DTO by identifier.
-        /// </summary>
-        /// <param name="id">The printing project identifier.</param>
-        /// <returns>A task that returns the matching <see cref="PrintingProjectDto"/> or <c>null</c> if not found.</returns>
-        Task<PrintingProjectDto?> GetPrintingProjectAsync(int id);
+    /// <summary>
+    ///     Retrieves a single manufacturer DTO by identifier.
+    /// </summary>
+    /// <param name="id">The manufacturer identifier.</param>
+    /// <returns>A task that returns the matching <see cref="ManufacturerDto" /> or <c>null</c> if not found.</returns>
+    Task<ManufacturerDto?> GetManufacturerAsync(int id);
 
-        /// <summary>
-        ///     Retrieves the path of the last imported file, if available.
-        /// </summary>
-        /// <returns>
-        ///     A string representing the path of the last imported file, or <c>null</c> if no import has been performed.
-        /// </returns>
-        string? GetLastImportPath();
+    /// <summary>
+    ///     Retrieves a single model design DTO by identifier.
+    /// </summary>
+    /// <param name="id">The model design identifier.</param>
+    /// <returns>A task that returns the matching <see cref="ModelDesignDto" /> or <c>null</c> if not found.</returns>
+    Task<ModelDesignDto?> GetModelDesignAsync(int id);
 
-        // Import operations
-        /// <summary>
-        ///     Import data from CSV (file path). Supports a directory containing per-entity CSV files or a single CSV file.
-        ///     Returns per-file results.
-        /// </summary>
-        Task<List<CsvImporter.ImportFileResult>> ImportFromCsvAsync(
-            string            csvPath,
-            ILogger           appLogger,
-            bool              updateExisting = true,
-            char              delimiter      = ',',
-            CancellationToken ct             = default);
+    /// <summary>
+    ///     Retrieves a single printer DTO by identifier.
+    /// </summary>
+    /// <param name="id">The printer identifier.</param>
+    /// <returns>A task that returns the matching <see cref="PrinterDto" /> or <c>null</c> if not found.</returns>
+    Task<PrinterDto?> GetPrinterAsync(int id);
 
-        /// <summary>
-        ///     Import data from a CSV stream. Optional fileName helps infer entity from the file name.
-        /// </summary>
-        Task<CsvImporter.ImportFileResult> ImportFromCsvAsync(
-            Stream            stream,
-            ILogger           appLogger,
-            string?           fileName       = null,
-            bool              updateExisting = true,
-            char              delimiter      = ',',
-            CancellationToken ct             = default);
+    /// <summary>
+    ///     Retrieves a single printing project DTO by identifier.
+    /// </summary>
+    /// <param name="id">The printing project identifier.</param>
+    /// <returns>A task that returns the matching <see cref="PrintingProjectDto" /> or <c>null</c> if not found.</returns>
+    Task<PrintingProjectDto?> GetPrintingProjectAsync(int id);
 
-        /// <summary>
-        ///     Sets the import path for the application.
-        /// </summary>
-        /// <param name="path">The file system path to set as the import path.</param>
-        /// <returns>The previously set import path, or <c>null</c> if no path was previously set.</returns>
-        void SetImportPath(string path);
-    }
+    // Import operations
+    /// <summary>
+    ///     Import data from CSV (file path). Supports a directory containing per-entity CSV files or a single CSV file.
+    ///     Returns per-file results.
+    /// </summary>
+    Task<List<CsvImporter.ImportFileResult>> ImportFromCsvAsync(
+        string            csvPath,
+        ILogger           appLogger,
+        bool              updateExisting = true,
+        char              delimiter      = ',',
+        CancellationToken ct             = default);
+
+    /// <summary>
+    ///     Import data from a CSV stream. Optional fileName helps infer entity from the file name.
+    /// </summary>
+    Task<CsvImporter.ImportFileResult> ImportFromCsvAsync(
+        Stream            stream,
+        ILogger           appLogger,
+        string?           fileName       = null,
+        bool              updateExisting = true,
+        char              delimiter      = ',',
+        CancellationToken ct             = default);
+
+    /// <summary>
+    ///     Sets the import path for the application.
+    /// </summary>
+    /// <param name="path">The file system path to set as the import path.</param>
+    /// <returns>The previously set import path, or <c>null</c> if no path was previously set.</returns>
+    void SetImportPath(string path);
 }

--- a/src/gCodeJournal.ViewModel/IGCodeJournalViewModel.cs
+++ b/src/gCodeJournal.ViewModel/IGCodeJournalViewModel.cs
@@ -187,6 +187,11 @@ public interface IGCodeJournalViewModel
     Task<ValidationResult> DeleteModelDesignAsync(ModelDesignDto modelDesignDto);
 
     /// <summary>
+    ///     Deletes the specified printer represented by a DTO.
+    /// </summary>
+    Task<ValidationResult> DeletePrinterAsync(PrinterDto printerDto);
+
+    /// <summary>
     ///     Deletes the specified printing project represented by a DTO.
     /// </summary>
     Task<ValidationResult> DeletePrintingProjectAsync(PrintingProjectDto printingProjectDto);

--- a/src/gCodeJournal.ViewModel/Import/CsvImporter.cs
+++ b/src/gCodeJournal.ViewModel/Import/CsvImporter.cs
@@ -225,17 +225,20 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
                                         break;
                                     }
 
-                                    if (manufacturer.Name.Equals(m.Name, StringComparison.OrdinalIgnoreCase))
+                                    // If name and flags all match, skip. Otherwise update the existing record.
+                                    if (manufacturer.Name.Equals(m.Name, StringComparison.OrdinalIgnoreCase)
+                                        && manufacturer.IsFilamentManufacturer == m.IsFilamentManufacturer
+                                        && manufacturer.IsPrinterManufacturer == m.IsPrinterManufacturer)
                                     {
                                         result.Skipped++;
 
                                         break;
                                     }
 
-                                    // Modify existing manufacturer
-                                    appLogger.LogDebug("Modifying existing manufacturer {@Manufacturer}; updating to {@NewName}", manufacturer, m.Name);
-                                    manufacturer.Name = m.Name;
-                                    await vm.EditManufacturerAsync(manufacturer).ConfigureAwait(false);
+                                    // Modify existing manufacturer properties via ViewModel API (DTO-based)
+                                    appLogger.LogDebug("Modifying existing manufacturer {@Manufacturer}; updating to {@NewValues}", manufacturer, m);
+                                    var editDto = new ManufacturerDto(manufacturer.Id, m.Name, m.IsFilamentManufacturer, m.IsPrinterManufacturer);
+                                    await vm.EditManufacturerAsync(editDto).ConfigureAwait(false);
                                     result.Updated++;
 
                                     break;
@@ -949,6 +952,8 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
                 {
                     var id   = ParseIntOrZero(GetString(dict, "Id"));
                     var name = GetString(dict, "Name");
+                    var isFilament = ParseBoolOrDefault(GetString(dict, "IsFilamentManufacturer") ?? GetString(dict, "IsFilament") ?? GetString(dict, "IsFilamentManufacturer"));
+                    var isPrinter  = ParseBoolOrDefault(GetString(dict, "IsPrinterManufacturer")  ?? GetString(dict, "IsPrinter")  ?? GetString(dict, "IsPrinterManufacturer"));
                     if (string.IsNullOrWhiteSpace(name))
                     {
                         result.Errors.Add("Manufacturer: Name is required");
@@ -957,7 +962,8 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
                         return;
                     }
 
-                    var dto = id != 0 ? new ManufacturerDto(id, name) : new ManufacturerDto(name);
+                    // Create DTO with flags. Use explicit id (0 when not supplied) so flags are preserved for new records.
+                    var dto = new ManufacturerDto(id, name, isFilament, isPrinter);
                     if (id != 0 && updateExisting)
                     {
                         var r = await vm.EditManufacturerAsync(dto).ConfigureAwait(false);
@@ -1481,6 +1487,25 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
             }
 
             return DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt) ? DateOnly.FromDateTime(dt) : DateOnly.MinValue;
+        }
+
+        static bool ParseBoolOrDefault(string? s)
+        {
+            if (string.IsNullOrWhiteSpace(s))
+            {
+                return false;
+            }
+
+            if (bool.TryParse(s, out var b))
+            {
+                return b;
+            }
+
+            // Accept common truthy values
+            return s.Equals("1", StringComparison.OrdinalIgnoreCase)
+                   || s.Equals("yes", StringComparison.OrdinalIgnoreCase)
+                   || s.Equals("y", StringComparison.OrdinalIgnoreCase)
+                   || s.Equals("true", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/gCodeJournal.ViewModel/Import/CsvImporter.cs
+++ b/src/gCodeJournal.ViewModel/Import/CsvImporter.cs
@@ -28,6 +28,7 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
         FilamentColours,
         FilamentTypes,
         Filaments,
+        Printers,
         ModelDesigns,
         PrintingProjects
     }
@@ -130,6 +131,7 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
         csv.Context.RegisterClassMap<FilamentColourMap>();
         csv.Context.RegisterClassMap<FilamentTypeMap>();
         csv.Context.RegisterClassMap<ManufacturerMap>();
+        csv.Context.RegisterClassMap<PrinterMap>();
         csv.Context.RegisterClassMap<ModelDesignMap>();
         csv.Context.RegisterClassMap<PrintingProjectMap>();
 
@@ -228,7 +230,7 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
                                     // If name and flags all match, skip. Otherwise update the existing record.
                                     if (manufacturer.Name.Equals(m.Name, StringComparison.OrdinalIgnoreCase)
                                         && manufacturer.IsFilamentManufacturer == m.IsFilamentManufacturer
-                                        && manufacturer.IsPrinterManufacturer == m.IsPrinterManufacturer)
+                                        && manufacturer.IsPrinterManufacturer  == m.IsPrinterManufacturer)
                                     {
                                         result.Skipped++;
 
@@ -588,6 +590,62 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
                         }
 
                         break;
+                    case ImportEntity.Printers:
+                        var printers = csv.GetRecords<PrinterDto>().ToList();
+                        foreach (var p in printers)
+                        {
+                            appLogger.LogDebug("Processing Printer DTO: {@Dto}", p);
+                            var sourceId = p.Id != 0 ? p.Id.ToString() : null;
+
+                            // Resolve manufacturer if provided as a nested DTO
+                            if (p.Manufacturer != null && p.Manufacturer.Id == 0 && !string.IsNullOrWhiteSpace(p.Manufacturer.Name))
+                            {
+                                await vm.AddManufacturerAsync(new ManufacturerDto(0, p.Manufacturer.Name)).ConfigureAwait(false);
+                                var all     = await vm.GetAllManufacturersAsync().ConfigureAwait(false);
+                                var matched = all.FirstOrDefault(m => string.Equals(m.Name, p.Manufacturer.Name, StringComparison.OrdinalIgnoreCase));
+                                if (matched != null)
+                                {
+                                    p.Manufacturer =
+                                        new ManufacturerDto(matched.Id, matched.Name, matched.IsFilamentManufacturer, matched.IsPrinterManufacturer);
+                                }
+                            }
+
+                            // Create or update via ViewModel API. Add/Edit methods for Printer are not present yet on VM,
+                            // fall back to direct DB operations to create entries.
+                            if (p.Id != 0 && updateExisting)
+                            {
+                                var existing = await db.Printers.FindAsync(p.Id).ConfigureAwait(false);
+                                if (existing != null)
+                                {
+                                    existing.Model = p.Model;
+                                    if (p.Manufacturer != null)
+                                    {
+                                        existing.ManufacturerId = p.Manufacturer.Id;
+                                    }
+
+                                    await db.SaveChangesAsync().ConfigureAwait(false);
+                                    result.Updated++;
+
+                                    continue;
+                                }
+                            }
+
+                            // Create new printer
+                            var printerEntity = new Printer {Model = p.Model, ManufacturerId = p.Manufacturer?.Id ?? 0};
+
+                            await db.Printers.AddAsync(printerEntity).ConfigureAwait(false);
+                            await db.SaveChangesAsync().ConfigureAwait(false);
+                            result.Created++;
+
+                            if (p.Id != 0)
+                            {
+                                result.RecordMapping("printers", p.Id.ToString(), printerEntity.Id);
+                            }
+                        }
+
+                        break;
+
+                    // (printing projects case is further below)
 
                     case ImportEntity.PrintingProjects:
                         var projects = csv.GetRecords<PrintingProjectDto>().ToList();
@@ -835,6 +893,11 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
             return ImportEntity.Filaments;
         }
 
+        if (name.Contains("printers", StringComparison.OrdinalIgnoreCase))
+        {
+            return ImportEntity.Printers;
+        }
+
         if (name.Contains("model_designs", StringComparison.OrdinalIgnoreCase))
         {
             return ImportEntity.ModelDesigns;
@@ -850,6 +913,7 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
         ImportEntity.FilamentColours  => "filament_colours.csv",
         ImportEntity.FilamentTypes    => "filament_types.csv",
         ImportEntity.Filaments        => "filaments.csv",
+        ImportEntity.Printers         => "printers.csv",
         ImportEntity.ModelDesigns     => "model_designs.csv",
         ImportEntity.PrintingProjects => "printing_projects.csv",
         _                             => string.Empty
@@ -863,6 +927,7 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
             "filament_colours" or "filamentcolours"                 => ImportEntity.FilamentColours,
             "filament_types" or "filamenttypes"                     => ImportEntity.FilamentTypes,
             "filaments" or "filament"                               => ImportEntity.Filaments,
+            "printers" or "printer"                                 => ImportEntity.Printers,
             "model_designs" or "modeldesigns" or "models"           => ImportEntity.ModelDesigns,
             "printing_projects" or "printingprojects" or "projects" => ImportEntity.PrintingProjects,
             _                                                       => ImportEntity.Unknown
@@ -952,8 +1017,12 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
                 {
                     var id   = ParseIntOrZero(GetString(dict, "Id"));
                     var name = GetString(dict, "Name");
-                    var isFilament = ParseBoolOrDefault(GetString(dict, "IsFilamentManufacturer") ?? GetString(dict, "IsFilament") ?? GetString(dict, "IsFilamentManufacturer"));
-                    var isPrinter  = ParseBoolOrDefault(GetString(dict, "IsPrinterManufacturer")  ?? GetString(dict, "IsPrinter")  ?? GetString(dict, "IsPrinterManufacturer"));
+                    var isFilament =
+                        ParseBoolOrDefault(
+                            GetString(dict, "IsFilamentManufacturer") ?? GetString(dict, "IsFilament") ?? GetString(dict, "IsFilamentManufacturer"));
+                    var isPrinter =
+                        ParseBoolOrDefault(
+                            GetString(dict, "IsPrinterManufacturer") ?? GetString(dict, "IsPrinter") ?? GetString(dict, "IsPrinterManufacturer"));
                     if (string.IsNullOrWhiteSpace(name))
                     {
                         result.Errors.Add("Manufacturer: Name is required");
@@ -1502,9 +1571,9 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
             }
 
             // Accept common truthy values
-            return s.Equals("1", StringComparison.OrdinalIgnoreCase)
-                   || s.Equals("yes", StringComparison.OrdinalIgnoreCase)
-                   || s.Equals("y", StringComparison.OrdinalIgnoreCase)
+            return s.Equals("1",       StringComparison.OrdinalIgnoreCase)
+                   || s.Equals("yes",  StringComparison.OrdinalIgnoreCase)
+                   || s.Equals("y",    StringComparison.OrdinalIgnoreCase)
                    || s.Equals("true", StringComparison.OrdinalIgnoreCase);
         }
     }

--- a/src/gCodeJournal.ViewModel/Import/CsvImporter.cs
+++ b/src/gCodeJournal.ViewModel/Import/CsvImporter.cs
@@ -592,6 +592,7 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
                         }
 
                         break;
+
                     case ImportEntity.Printers:
                         var printers = csv.GetRecords<PrinterDto>().ToList();
                         foreach (var p in printers)
@@ -599,55 +600,54 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
                             appLogger.LogDebug("Processing Printer DTO: {@Dto}", p);
                             var sourceId = p.Id != 0 ? p.Id.ToString() : null;
 
-                            // Resolve manufacturer if provided as a nested DTO
-                            if (p.Manufacturer != null && p.Manufacturer.Id == 0 && !string.IsNullOrWhiteSpace(p.Manufacturer.Name))
+                            var r = await vm.AddPrinterAsync(p).ConfigureAwait(false);
+                            switch (r)
                             {
-                                await vm.AddManufacturerAsync(new ManufacturerDto(0, p.Manufacturer.Name)).ConfigureAwait(false);
-                                var all     = await vm.GetAllManufacturersAsync().ConfigureAwait(false);
-                                var matched = all.FirstOrDefault(m => string.Equals(m.Name, p.Manufacturer.Name, StringComparison.OrdinalIgnoreCase));
-                                if (matched != null)
-                                {
-                                    p.Manufacturer =
-                                        new ManufacturerDto(matched.Id, matched.Name, matched.IsFilamentManufacturer, matched.IsPrinterManufacturer);
-                                }
-                            }
+                                case (var v, AddRecordResult.Added) when v == ValidationResult.Success:
+                                    // added
+                                    result.Created++;
 
-                            // Create or update via ViewModel API. Add/Edit methods for Printer are not present yet on VM,
-                            // fall back to direct DB operations to create entries.
-                            if (p.Id != 0 && updateExisting)
-                            {
-                                var existing = await db.Printers.FindAsync(p.Id).ConfigureAwait(false);
-                                if (existing != null)
-                                {
-                                    existing.Model = p.Model;
-                                    if (p.Manufacturer != null)
+                                    break;
+
+                                case (var v, AddRecordResult.Exists) when v == ValidationResult.Success:
+                                    // Exists - check that properties match
+                                    var printerDto = await vm.GetPrinterAsync(p.Id).ConfigureAwait(false);
+                                    if (printerDto is null)
                                     {
-                                        existing.ManufacturerId = p.Manufacturer.Id;
+                                        result.Errors.Add($"Model with ID {p.Id} not found");
+                                        result.Failed++;
+
+                                        break;
                                     }
 
-                                    await db.SaveChangesAsync().ConfigureAwait(false);
+                                    var comparisonResult = printerDto.CompareTo(p);
+                                    if (comparisonResult.IsMatch)
+                                    {
+                                        result.Skipped++;
+
+                                        break;
+                                    }
+
+                                    // Modify existing printer
+                                    appLogger.LogDebug("Modifying existing printer {@Printer}",   printerDto);
+                                    appLogger.LogDebug("Properties to be updated: {@Properties}", string.Join(',', comparisonResult.MismatchedProperties));
+                                    printerDto.Model        = p.Model;
+                                    printerDto.Manufacturer = p.Manufacturer;
+                                    printerDto.CostPerHour  = p.CostPerHour;
+                                    await vm.EditPrinterAsync(printerDto).ConfigureAwait(false);
                                     result.Updated++;
 
-                                    continue;
-                                }
-                            }
+                                    break;
 
-                            // Create new printer
-                            var printerEntity = new Printer {Model = p.Model, ManufacturerId = p.Manufacturer?.Id ?? 0};
+                                case var (v, _) when v != ValidationResult.Success:
+                                    // validation error
+                                    result.Errors.Add(v.ErrorMessage ?? $"{nameof(vm.AddPrinterAsync)} failed");
 
-                            await db.Printers.AddAsync(printerEntity).ConfigureAwait(false);
-                            await db.SaveChangesAsync().ConfigureAwait(false);
-                            result.Created++;
-
-                            if (p.Id != 0)
-                            {
-                                result.RecordMapping("printers", p.Id.ToString(), printerEntity.Id);
+                                    break;
                             }
                         }
 
                         break;
-
-                    // (printing projects case is further below)
 
                     case ImportEntity.PrintingProjects:
                         var projects = csv.GetRecords<PrintingProjectDto>().ToList();
@@ -1417,6 +1417,7 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
                     var cost           = ParseDecimalOrZero(GetString(dict,     "Cost"));
                     var submitted      = ParseDateOnlyOrDefault(GetString(dict, "Submitted"));
                     var completed      = ParseDateOnlyOrDefault(GetString(dict, "Completed"));
+                    var costPerHour    = ParseDecimalOrZero(GetString(dict,     "CostPerHour"));
                     var customerId     = ParseIntOrZero(GetString(dict, "CustomerId")    ?? GetString(dict, "Customer"));
                     var modelId        = ParseIntOrZero(GetString(dict, "ModelDesignId") ?? GetString(dict, "ModelDesign"));
                     var filamentIdsRaw = GetString(dict, "FilamentIds") ?? GetString(dict, "FilamentId") ?? GetString(dict, "Filaments");
@@ -1431,6 +1432,33 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
                     if (modelId != 0)
                     {
                         modelDto = new ModelDesignDto(modelId, string.Empty, 0m, string.Empty, null);
+                    }
+
+                    // Parse printer information: prefer explicit id, then separate Manufacturer/Model columns, then single Printer column
+                    var         printerId  = ParseIntOrZero(GetString(dict, "PrinterId") ?? GetString(dict, "Printer"));
+                    PrinterDto? printerDto = null;
+                    if (printerId != 0)
+                    {
+                        printerDto = new PrinterDto(printerId, string.Empty);
+                    }
+                    else
+                    {
+                        var printerManufacturer = GetString(dict, "PrinterManufacturer") ?? GetString(dict, "PrinterMaker") ?? GetString(dict, "PrinterBrand");
+                        var printerModel        = GetString(dict, "PrinterModel");
+
+                        if (!string.IsNullOrWhiteSpace(printerManufacturer) || !string.IsNullOrWhiteSpace(printerModel))
+                        {
+                            if (!string.IsNullOrWhiteSpace(printerManufacturer))
+                            {
+                                var manu = new ManufacturerDto(0, printerManufacturer!.Trim());
+                                printerDto = new PrinterDto(manu, printerModel?.Trim() ?? string.Empty, costPerHour);
+                            }
+                            else
+                            {
+                                // Manufacturer missing - use model only
+                                printerDto = new PrinterDto(0, null, printerModel?.Trim() ?? string.Empty, costPerHour);
+                            }
+                        }
                     }
 
                     var filamentDtos = new List<FilamentDto>();
@@ -1468,6 +1496,7 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
                                 completed == DateOnly.MinValue ? null : completed,
                                 customerDto,
                                 modelDto,
+                                printerDto,
                                 filamentDtos)
                             : new PrintingProjectDto(
                                 cost,
@@ -1475,6 +1504,7 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
                                 completed == DateOnly.MinValue ? null : completed,
                                 customerDto,
                                 modelDto,
+                                printerDto,
                                 filamentDtos);
 
                     if (id != 0 && updateExisting)

--- a/src/gCodeJournal.ViewModel/Import/CsvImporter.cs
+++ b/src/gCodeJournal.ViewModel/Import/CsvImporter.cs
@@ -63,6 +63,7 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
                     ImportEntity.FilamentTypes,
                     ImportEntity.Filaments,
                     ImportEntity.ModelDesigns,
+                    ImportEntity.Printers,
                     ImportEntity.PrintingProjects
                 };
 
@@ -167,6 +168,7 @@ public class CsvImporter(GCodeJournalDbContext db, GCodeJournalViewModel vm)
 
                                 case (var v, AddRecordResult.Exists) when v == ValidationResult.Success:
                                     // Exists - check that properties match
+                                    // TODO: Match by name or use existing record returned by AddCustomerAsync when record exists to avoid extra DB call here. This requires changing the AddCustomerAsync API to return the existing record DTO when record exists, or at least its properties for comparison.
                                     var customer = await vm.GetCustomerAsync(c.Id).ConfigureAwait(false);
                                     if (customer is null)
                                     {

--- a/src/gCodeJournal.ViewModel/Import/Maps/ManufacturerMap.cs
+++ b/src/gCodeJournal.ViewModel/Import/Maps/ManufacturerMap.cs
@@ -13,6 +13,8 @@ public sealed class ManufacturerMap : ClassMap<ManufacturerDto>
     public ManufacturerMap()
     {
         Map(m => m.Id).Optional();
+        Map(m => m.IsFilamentManufacturer).Optional();
+        Map(m => m.IsPrinterManufacturer).Optional();
         Map(m => m.Name);
     }
     #endregion

--- a/src/gCodeJournal.ViewModel/Import/Maps/PrinterMap.cs
+++ b/src/gCodeJournal.ViewModel/Import/Maps/PrinterMap.cs
@@ -1,0 +1,60 @@
+// gCodeJournal.ViewModel
+
+namespace gCodeJournal.ViewModel.Import.Maps;
+
+#region Using Directives
+using CsvHelper.Configuration;
+using DTOs;
+#endregion
+
+/// <summary>
+/// CSV map for printers.csv
+/// Expects columns: Id (optional), ManufacturerId/Manufacturer, Model
+/// </summary>
+public sealed class PrinterMap : ClassMap<PrinterDto>
+{
+    public PrinterMap()
+    {
+        Map(m => m.Id).Name("Id").Optional();
+
+        Map(m => m.Manufacturer)
+            .Convert(args =>
+                     {
+                         var row = args.Row;
+                         var field = TryGetField(row, "ManufacturerId") ?? TryGetField(row, "Manufacturer");
+                         if (string.IsNullOrWhiteSpace(field))
+                         {
+                             return null;
+                         }
+
+                         var id = ParseIntOrZero(field);
+                         if (id != 0)
+                         {
+                             return new ManufacturerDto(id, string.Empty);
+                         }
+
+                         return new ManufacturerDto(field.Trim());
+                     });
+
+        Map(m => m.Model).Name("Model").Name("PrinterModel");
+    }
+
+    static int ParseIntOrZero(string? s) => int.TryParse(s, out var i) ? i : 0;
+
+    static string? TryGetField(CsvHelper.IReaderRow row, string name)
+    {
+        try
+        {
+            if (row == null)
+            {
+                return null;
+            }
+
+            return row.TryGetField(name, out string? value) ? value : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/gCodeJournal.ViewModel/Import/Maps/PrinterMap.cs
+++ b/src/gCodeJournal.ViewModel/Import/Maps/PrinterMap.cs
@@ -34,7 +34,7 @@ public sealed class PrinterMap : ClassMap<PrinterDto>
                          return id != 0 ? new ManufacturerDto(id, string.Empty) : new ManufacturerDto(field.Trim());
                      });
 
-        Map(m => m.Model).Name("Model").Name("PrinterModel");
+        Map(m => m.Model).Name("Model", "PrinterModel");
     }
     #endregion
 

--- a/src/gCodeJournal.ViewModel/Import/Maps/PrinterMap.cs
+++ b/src/gCodeJournal.ViewModel/Import/Maps/PrinterMap.cs
@@ -3,16 +3,18 @@
 namespace gCodeJournal.ViewModel.Import.Maps;
 
 #region Using Directives
+using CsvHelper;
 using CsvHelper.Configuration;
 using DTOs;
 #endregion
 
 /// <summary>
-/// CSV map for printers.csv
-/// Expects columns: Id (optional), ManufacturerId/Manufacturer, Model
+///     CSV map for printers.csv
+///     Expects columns: Id (optional), ManufacturerId/Manufacturer, Model
 /// </summary>
 public sealed class PrinterMap : ClassMap<PrinterDto>
 {
+    #region Constructors
     public PrinterMap()
     {
         Map(m => m.Id).Name("Id").Optional();
@@ -20,7 +22,7 @@ public sealed class PrinterMap : ClassMap<PrinterDto>
         Map(m => m.Manufacturer)
             .Convert(args =>
                      {
-                         var row = args.Row;
+                         var row   = args.Row;
                          var field = TryGetField(row, "ManufacturerId") ?? TryGetField(row, "Manufacturer");
                          if (string.IsNullOrWhiteSpace(field))
                          {
@@ -28,20 +30,17 @@ public sealed class PrinterMap : ClassMap<PrinterDto>
                          }
 
                          var id = ParseIntOrZero(field);
-                         if (id != 0)
-                         {
-                             return new ManufacturerDto(id, string.Empty);
-                         }
 
-                         return new ManufacturerDto(field.Trim());
+                         return id != 0 ? new ManufacturerDto(id, string.Empty) : new ManufacturerDto(field.Trim());
                      });
 
         Map(m => m.Model).Name("Model").Name("PrinterModel");
     }
+    #endregion
 
     static int ParseIntOrZero(string? s) => int.TryParse(s, out var i) ? i : 0;
 
-    static string? TryGetField(CsvHelper.IReaderRow row, string name)
+    static string? TryGetField(IReaderRow row, string name)
     {
         try
         {

--- a/src/gCodeJournal.ViewModel/Import/Maps/PrinterMap.cs
+++ b/src/gCodeJournal.ViewModel/Import/Maps/PrinterMap.cs
@@ -18,7 +18,7 @@ public sealed class PrinterMap : ClassMap<PrinterDto>
     public PrinterMap()
     {
         Map(m => m.Id).Name("Id").Optional();
-
+        Map(m => m.CostPerHour).Name("CostPerHour").Optional();
         Map(m => m.Manufacturer)
             .Convert(args =>
                      {

--- a/src/gCodeJournal.ViewModel/Import/Maps/PrintingProjectMap.cs
+++ b/src/gCodeJournal.ViewModel/Import/Maps/PrintingProjectMap.cs
@@ -70,6 +70,50 @@ public sealed class PrintingProjectMap : ClassMap<PrintingProjectDto>
                          return new ModelDesignDto(0, string.Empty, 0m, field.Trim(), null);
                      });
 
+        Map(m => m.Printer)
+            .Convert(args =>
+                     {
+                         var row = args.Row;
+
+                         // Prefer explicit id if present
+                         var idField = TryGetField(row, "PrinterId");
+                         if (!string.IsNullOrWhiteSpace(idField))
+                         {
+                             var id = ParseIntOrZero(idField);
+                             if (id != 0)
+                             {
+                                 return new PrinterDto(id, string.Empty);
+                             }
+                         }
+
+                         // If provided as separate Manufacturer + Model columns, prefer those
+                         var manuField  = TryGetField(row, "PrinterManufacturer") ?? TryGetField(row, "PrinterMaker") ?? TryGetField(row, "PrinterBrand");
+                         var modelField = TryGetField(row, "PrinterModel");
+                         _ = decimal.TryParse(TryGetField(row, "CostPerHour"), out var costPerHour);
+                         if (!string.IsNullOrWhiteSpace(manuField) || !string.IsNullOrWhiteSpace(modelField))
+                         {
+                             var manu  = new ManufacturerDto(0, (manuField ?? string.Empty).Trim());
+                             var model = (modelField ?? string.Empty).Trim();
+
+                             return new PrinterDto(manu, model, costPerHour);
+                         }
+
+                         // Fallback to single 'Printer' column (may be id or model)
+                         var printerIdField = TryGetField(row, "Printer");
+                         if (string.IsNullOrWhiteSpace(printerIdField))
+                         {
+                             return null;
+                         }
+
+                         var printerId = ParseIntOrZero(printerIdField);
+                         if (printerId != 0)
+                         {
+                             return new PrinterDto(printerId, null, string.Empty, costPerHour);
+                         }
+
+                         return new PrinterDto(0, null, printerIdField.Trim(), costPerHour);
+                     });
+
         Map(m => m.Filaments)
             .Convert(args =>
                      {

--- a/src/gCodeJournal.ViewModel/Mapping/DtoToEntityExtensions.cs
+++ b/src/gCodeJournal.ViewModel/Mapping/DtoToEntityExtensions.cs
@@ -1,3 +1,5 @@
+// gCodeJournal.ViewModel
+
 namespace gCodeJournal.ViewModel.Mapping;
 
 #region Using Directives
@@ -7,30 +9,35 @@ using Model;
 
 public static class DtoToEntityExtensions
 {
-    public static Customer ToEntity(this CustomerDto dto) => new () {Id = dto.Id, Name = dto.Name};
+    public static Customer ToEntity(this CustomerDto dto) => new() {Id = dto.Id, Name = dto.Name};
 
-    public static Manufacturer ToEntity(this ManufacturerDto dto) => new () {Id = dto.Id, Name = dto.Name, IsFilamentManufacturer = dto.IsFilamentManufacturer, IsPrinterManufacturer = dto.IsPrinterManufacturer};
+    public static Manufacturer ToEntity(this ManufacturerDto dto) => new()
+    {
+        Id = dto.Id, Name = dto.Name, IsFilamentManufacturer = dto.IsFilamentManufacturer, IsPrinterManufacturer = dto.IsPrinterManufacturer
+    };
 
-    public static FilamentColour ToEntity(this FilamentColourDto dto) => new () {Id = dto.Id, Description = dto.Description};
+    public static FilamentColour ToEntity(this FilamentColourDto dto) => new() {Id = dto.Id, Description = dto.Description};
 
-    public static FilamentType ToEntity(this FilamentTypeDto dto) => new () {Id = dto.Id, Description = dto.Description};
+    public static FilamentType ToEntity(this FilamentTypeDto dto) => new() {Id = dto.Id, Description = dto.Description};
 
     public static Filament ToEntity(this FilamentDto dto)
     {
-        var filament = new Filament
-        {
-            Id               = dto.Id,
-            CostPerWeight    = dto.CostPerWeight,
-            ProductId        = dto.ProductId,
-            ReorderLink      = dto.ReorderLink,
-            ManufacturerId   = dto.Manufacturer?.Id   ?? 0,
-            FilamentColourId = dto.FilamentColour?.Id ?? 0,
-            FilamentTypeId   = dto.FilamentType?.Id   ?? 0
-        };
+        var filament =
+            new Filament
+            {
+                Id               = dto.Id,
+                CostPerWeight    = dto.CostPerWeight,
+                ProductId        = dto.ProductId,
+                ReorderLink      = dto.ReorderLink,
+                ManufacturerId   = dto.Manufacturer?.Id   ?? 0,
+                FilamentColourId = dto.FilamentColour?.Id ?? 0,
+                FilamentTypeId   = dto.FilamentType?.Id   ?? 0
+            };
+
         return filament;
     }
 
-    public static ModelDesign ToEntity(this ModelDesignDto dto) => new ()
+    public static ModelDesign ToEntity(this ModelDesignDto dto) => new()
     {
         Id          = dto.Id,
         Description = dto.Description,
@@ -39,17 +46,26 @@ public static class DtoToEntityExtensions
         Url         = dto.Url
     };
 
+    public static Printer ToEntity(this PrinterDto dto)
+    {
+        var printer = new Printer {Id = dto.Id, Model = dto.Model, ManufacturerId = dto.Manufacturer?.Id ?? 0, CostPerHour = dto.CostPerHour};
+
+        return printer;
+    }
+
     public static PrintingProject ToEntity(this PrintingProjectDto dto)
     {
-        var project = new PrintingProject
-        {
-            Id            = dto.Id,
-            Cost          = dto.Cost,
-            Submitted     = dto.Submitted.ToDateTime(TimeOnly.MinValue),
-            Completed     = dto.Completed?.ToDateTime(TimeOnly.MinValue),
-            CustomerId    = dto.Customer?.Id    ?? 0,
-            ModelDesignId = dto.ModelDesign?.Id ?? 0
-        };
+        var project =
+            new PrintingProject
+            {
+                Id            = dto.Id,
+                Cost          = dto.Cost,
+                Submitted     = dto.Submitted.ToDateTime(TimeOnly.MinValue),
+                Completed     = dto.Completed?.ToDateTime(TimeOnly.MinValue),
+                CustomerId    = dto.Customer?.Id    ?? 0,
+                ModelDesignId = dto.ModelDesign?.Id ?? 0
+            };
+
         return project;
     }
 }

--- a/src/gCodeJournal.ViewModel/Mapping/DtoToEntityExtensions.cs
+++ b/src/gCodeJournal.ViewModel/Mapping/DtoToEntityExtensions.cs
@@ -9,7 +9,7 @@ public static class DtoToEntityExtensions
 {
     public static Customer ToEntity(this CustomerDto dto) => new () {Id = dto.Id, Name = dto.Name};
 
-    public static Manufacturer ToEntity(this ManufacturerDto dto) => new () {Id = dto.Id, Name = dto.Name};
+    public static Manufacturer ToEntity(this ManufacturerDto dto) => new () {Id = dto.Id, Name = dto.Name, IsFilamentManufacturer = dto.IsFilamentManufacturer, IsPrinterManufacturer = dto.IsPrinterManufacturer};
 
     public static FilamentColour ToEntity(this FilamentColourDto dto) => new () {Id = dto.Id, Description = dto.Description};
 

--- a/src/gcj/Actions/Add.cs
+++ b/src/gcj/Actions/Add.cs
@@ -1,203 +1,219 @@
-﻿namespace gcj
+﻿// gcj
+
+namespace gcj;
+
+#region Using Directives
+using gCodeJournal.ViewModel;
+using gCodeJournal.ViewModel.DTOs;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+#endregion
+
+public static partial class Program
 {
-    #region Using Directives
-    using gCodeJournal.ViewModel;
-    using gCodeJournal.ViewModel.DTOs;
-    using Microsoft.Extensions.Logging;
-    using Spectre.Console;
-    #endregion
-
-    public static partial class Program
+    static async Task AddCustomerAsync(IGCodeJournalViewModel vm, ILogger appLogger)
     {
-        private static async Task AddCustomerAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+        var customerName = await string.Empty.ValidateCustomerNameInputAsync(appLogger).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(customerName))
         {
-            var customerName = await string.Empty.ValidateCustomerNameInputAsync(appLogger).ConfigureAwait(false);
-            if (string.IsNullOrWhiteSpace(customerName))
-            {
-                return;
-            }
-
-            await vm.AddCustomerAsync(new CustomerDto(customerName)).ConfigureAwait(false);
-            appLogger.LogInformation(Emoji.Known.CheckMarkButton + " Added customer {Name}", customerName);
+            return;
         }
 
-        private static async Task AddFilamentAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+        await vm.AddCustomerAsync(new CustomerDto(customerName)).ConfigureAwait(false);
+        appLogger.LogInformation(Emoji.Known.CheckMarkButton + " Added customer {Name}", customerName);
+    }
+
+    static async Task AddFilamentAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+    {
+        var colours       = await vm.GetAllFilamentColoursAsync().ConfigureAwait(false);
+        var filamentTypes = await vm.GetAllFilamentTypesAsync().ConfigureAwait(false);
+        var manufacturers = await vm.GetAllManufacturersAsync().ConfigureAwait(false);
+        if (!colours.Any() || !filamentTypes.Any() || !manufacturers.Any())
         {
-            var colours       = await vm.GetAllFilamentColoursAsync().ConfigureAwait(false);
-            var filamentTypes = await vm.GetAllFilamentTypesAsync().ConfigureAwait(false);
-            var manufacturers = await vm.GetAllManufacturersAsync().ConfigureAwait(false);
-            if (!colours.Any() || !filamentTypes.Any() || !manufacturers.Any())
+            string missing;
+            if (colours.Any())
             {
-                string missing;
-                if (colours.Any())
-                {
-                    missing = filamentTypes.Any() ? "manufacturers" : "filament types";
-                }
-                else
-                {
-                    missing = "colours";
-                }
-
-                appLogger.LogError("No {MissingElement} found; cannot create a Filament without colour", missing);
-                return;
-            }
-
-            var manufacturer = await ValidateManufacturerSelectionAsync(appLogger, manufacturers).ConfigureAwait(false);
-            if (manufacturer is null)
-            {
-                return;
-            }
-
-            var filamentType = await filamentTypes.GetEntitySelectionAsync().ConfigureAwait(false);
-            if (filamentType is null)
-            {
-                // User chose to go back to the menu
-                appLogger.LogReturnToMenu();
-                return;
-            }
-
-            var colour = await colours.GetEntitySelectionAsync().ConfigureAwait(false);
-            if (colour is null)
-            {
-                // User chose to go back to the menu
-                appLogger.LogReturnToMenu();
-                return;
-            }
-
-            var costPerWeight = await 0m.GetFilamentCostPerWeightAsync().ConfigureAwait(false);
-            var productCode   = await string.Empty.GetFilamentProductIdAsync().ConfigureAwait(false);
-            var productUrl    = await string.Empty.GetFilamentProductUrlAsync().ConfigureAwait(false);
-            var filamentDto   = new FilamentDto(costPerWeight, productCode, productUrl, colour, filamentType, manufacturer);
-            await vm.AddFilamentAsync(filamentDto).ConfigureAwait(false);
-            appLogger.LogInformation(Emoji.Known.CheckMarkButton + " Added filament {Filament}", filamentDto);
-        }
-
-        private static async Task AddFilamentColourAsync(IGCodeJournalViewModel vm, ILogger appLogger)
-        {
-            var filamentColour = await "filament colour".GetInputFromConsoleAsync().ConfigureAwait(false);
-            if (string.IsNullOrWhiteSpace(filamentColour))
-            {
-                appLogger.LogError(Emoji.Known.Warning + "  filament colour cannot be empty");
-                return;
-            }
-
-            await vm.AddFilamentColourAsync(new FilamentColourDto(filamentColour)).ConfigureAwait(false);
-            appLogger.LogInformation(Emoji.Known.CheckMarkButton + " Added filament colour {Colour}", filamentColour);
-        }
-
-        private static async Task AddFilamentTypeAsync(IGCodeJournalViewModel vm, ILogger appLogger)
-        {
-            var filamentType = await string.Empty.GetFilamentTypeAsync().ConfigureAwait(false);
-            if (string.IsNullOrWhiteSpace(filamentType))
-            {
-                appLogger.LogError(Emoji.Known.Warning + "  filament type cannot be empty");
-                return;
-            }
-
-            await vm.AddFilamentTypeAsync(new FilamentTypeDto(filamentType)).ConfigureAwait(false);
-            appLogger.LogInformation(Emoji.Known.CheckMarkButton + " Added filament type {Type}", filamentType);
-        }
-
-        private static async Task AddManufacturerAsync(IGCodeJournalViewModel vm, ILogger appLogger)
-        {
-            var manufacturerName = await string.Empty.GetManufacturerAsync().ConfigureAwait(false);
-            if (string.IsNullOrWhiteSpace(manufacturerName))
-            {
-                appLogger.LogError(Emoji.Known.Warning + "  Manufacturer name cannot be empty");
-                return;
-            }
-
-            await vm.AddManufacturerAsync(new ManufacturerDto(manufacturerName)).ConfigureAwait(false);
-            appLogger.LogInformation(Emoji.Known.CheckMarkButton + " Added manufacturer {Name}", manufacturerName);
-        }
-
-        private static async Task AddModelDesignAsync(IGCodeJournalViewModel vm, ILogger appLogger)
-        {
-            var summary     = await string.Empty.GetModelSummary().ConfigureAwait(false);
-            var description = await string.Empty.GetModelDescriptionAsync().ConfigureAwait(false);
-            var length      = await 0m.GetModelLengthAsync().ConfigureAwait(false);
-            var url         = await "model URL".GetUriAsync().ConfigureAwait(false);
-
-            if (string.IsNullOrWhiteSpace(summary))
-            {
-                appLogger.LogError(Emoji.Known.Warning + "  Summary cannot be empty");
-                return;
-            }
-
-            if (string.IsNullOrWhiteSpace(description))
-            {
-                appLogger.LogError(Emoji.Known.Warning + "  Description cannot be empty");
-                return;
-            }
-
-            await vm.AddModelDesignAsync(new ModelDesignDto(description, length, summary, url)).ConfigureAwait(false);
-            appLogger.LogInformation(Emoji.Known.CheckMarkButton + " Added model design {Summary}", summary);
-        }
-
-        private static async Task AddPrintingProjectAsync(IGCodeJournalViewModel vm, ILogger appLogger)
-        {
-            var customers = await vm.GetAllCustomersAsync().ConfigureAwait(false);
-            var models    = await vm.GetAllModelDesignsAsync().ConfigureAwait(false);
-            var filaments = await vm.GetAllFilamentsAsync().ConfigureAwait(false);
-            if (!customers.Any() || !models.Any() || !filaments.Any())
-            {
-                string missing;
-                if (customers.Any())
-                {
-                    missing = models.Any() ? "filaments" : "models";
-                }
-                else
-                {
-                    missing = "customers";
-                }
-
-                appLogger.LogError("No {MissingElement} found; cannot create a project without it", missing);
-                return;
-            }
-
-            var customer = await customers.GetEntitySelectionAsync().ConfigureAwait(false);
-            if (customer is null)
-            {
-                // User chose to go back to the menu
-                appLogger.LogReturnToMenu();
-                return;
-            }
-
-            appLogger.LogInformation(Emoji.Known.OkButton + " Selected customer: {Customer}", customer);
-
-            var model = await models.GetEntitySelectionAsync().ConfigureAwait(false);
-            if (model is null)
-            {
-                // User chose to go back to the menu
-                appLogger.LogReturnToMenu();
-                return;
-            }
-
-            appLogger.LogInformation(Emoji.Known.OkButton + " Selected model: {Model}", model);
-
-            var selectedFilaments = await filaments.SelectFilamentsAsync(appLogger);
-            var cost              = await "cost".GetInputFromConsoleAsync<decimal>().ConfigureAwait(false); // TODO: Calculate from filament and length
-            var dateSubmitted = await "submitted".GetDateFromConsoleAsync(DateOnly.FromDateTime(DateTime.Today)).ConfigureAwait(false)
-                                ?? DateOnly.FromDateTime(DateTime.Today);
-            var dateCompleted = await "completed".GetDateFromConsoleAsync().ConfigureAwait(false);
-
-            appLogger.LogInformation(Emoji.Known.OkButton + " Set cost to {Cost}",                   cost.ToString("C2"));
-            appLogger.LogInformation(Emoji.Known.OkButton + " Set DateSubmitted to {DateSubmitted}", dateSubmitted.ToShortDateString());
-            if (dateCompleted.HasValue)
-            {
-                appLogger.LogInformation(Emoji.Known.OkButton + " Set DateCompleted to {DateCompleted}", dateCompleted.Value.ToShortDateString());
+                missing = filamentTypes.Any() ? "manufacturers" : "filament types";
             }
             else
             {
-                appLogger.LogInformation(Emoji.Known.OkButton + " Not completed");
+                missing = "colours";
             }
 
-            await vm.AddPrintingProjectAsync(new PrintingProjectDto(cost, dateSubmitted, dateCompleted, customer, model, selectedFilaments)).ConfigureAwait(false);
-            appLogger.LogInformation(
-                Emoji.Known.CheckMarkButton + " Added project {Model} for {Customer} with filaments {Filaments}",
-                model,
-                customer,
-                string.Join(", ", selectedFilaments));
+            appLogger.LogError("No {MissingElement} found; cannot create a Filament without colour", missing);
+
+            return;
         }
+
+        var manufacturer = await ValidateManufacturerSelectionAsync(appLogger, manufacturers).ConfigureAwait(false);
+        if (manufacturer is null)
+        {
+            return;
+        }
+
+        var filamentType = await filamentTypes.GetEntitySelectionAsync().ConfigureAwait(false);
+        if (filamentType is null)
+        {
+            // User chose to go back to the menu
+            appLogger.LogReturnToMenu();
+
+            return;
+        }
+
+        var colour = await colours.GetEntitySelectionAsync().ConfigureAwait(false);
+        if (colour is null)
+        {
+            // User chose to go back to the menu
+            appLogger.LogReturnToMenu();
+
+            return;
+        }
+
+        var costPerWeight = await 0m.GetFilamentCostPerWeightAsync().ConfigureAwait(false);
+        var productCode   = await string.Empty.GetFilamentProductIdAsync().ConfigureAwait(false);
+        var productUrl    = await string.Empty.GetFilamentProductUrlAsync().ConfigureAwait(false);
+        var filamentDto   = new FilamentDto(costPerWeight, productCode, productUrl, colour, filamentType, manufacturer);
+        await vm.AddFilamentAsync(filamentDto).ConfigureAwait(false);
+        appLogger.LogInformation(Emoji.Known.CheckMarkButton + " Added filament {Filament}", filamentDto);
+    }
+
+    static async Task AddFilamentColourAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+    {
+        var filamentColour = await "filament colour".GetInputFromConsoleAsync().ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(filamentColour))
+        {
+            appLogger.LogError(Emoji.Known.Warning + "  filament colour cannot be empty");
+
+            return;
+        }
+
+        await vm.AddFilamentColourAsync(new FilamentColourDto(filamentColour)).ConfigureAwait(false);
+        appLogger.LogInformation(Emoji.Known.CheckMarkButton + " Added filament colour {Colour}", filamentColour);
+    }
+
+    static async Task AddFilamentTypeAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+    {
+        var filamentType = await string.Empty.GetFilamentTypeAsync().ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(filamentType))
+        {
+            appLogger.LogError(Emoji.Known.Warning + "  filament type cannot be empty");
+
+            return;
+        }
+
+        await vm.AddFilamentTypeAsync(new FilamentTypeDto(filamentType)).ConfigureAwait(false);
+        appLogger.LogInformation(Emoji.Known.CheckMarkButton + " Added filament type {Type}", filamentType);
+    }
+
+    static async Task AddManufacturerAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+    {
+        var manufacturerName = await string.Empty.GetManufacturerAsync().ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(manufacturerName))
+        {
+            appLogger.LogError(Emoji.Known.Warning + "  Manufacturer name cannot be empty");
+
+            return;
+        }
+
+        await vm.AddManufacturerAsync(new ManufacturerDto(manufacturerName)).ConfigureAwait(false);
+        appLogger.LogInformation(Emoji.Known.CheckMarkButton + " Added manufacturer {Name}", manufacturerName);
+    }
+
+    static async Task AddModelDesignAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+    {
+        var summary     = await string.Empty.GetModelSummary().ConfigureAwait(false);
+        var description = await string.Empty.GetModelDescriptionAsync().ConfigureAwait(false);
+        var length      = await 0m.GetModelLengthAsync().ConfigureAwait(false);
+        var url         = await "model URL".GetUriAsync().ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(summary))
+        {
+            appLogger.LogError(Emoji.Known.Warning + "  Summary cannot be empty");
+
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            appLogger.LogError(Emoji.Known.Warning + "  Description cannot be empty");
+
+            return;
+        }
+
+        await vm.AddModelDesignAsync(new ModelDesignDto(description, length, summary, url)).ConfigureAwait(false);
+        appLogger.LogInformation(Emoji.Known.CheckMarkButton + " Added model design {Summary}", summary);
+    }
+
+    static async Task AddPrintingProjectAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+    {
+        var customers = await vm.GetAllCustomersAsync().ConfigureAwait(false);
+        var models    = await vm.GetAllModelDesignsAsync().ConfigureAwait(false);
+        var filaments = await vm.GetAllFilamentsAsync().ConfigureAwait(false);
+        var printers  = await vm.GetAllPrintersAsync().ConfigureAwait(false);
+        if (!customers.Any() || !models.Any() || !filaments.Any() || !printers.Any())
+        {
+            string missing;
+            if (customers.Any())
+            {
+                missing = models.Any() ? "filaments" : "models";
+            }
+            else
+            {
+                missing = "customers";
+            }
+
+            appLogger.LogError("No {MissingElement} found; cannot create a project without it", missing);
+
+            return;
+        }
+
+        var customer = await customers.GetEntitySelectionAsync().ConfigureAwait(false);
+        if (customer is null)
+        {
+            // User chose to go back to the menu
+            appLogger.LogReturnToMenu();
+
+            return;
+        }
+
+        appLogger.LogInformation(Emoji.Known.OkButton + " Selected customer: {Customer}", customer);
+
+        var model = await models.GetEntitySelectionAsync().ConfigureAwait(false);
+        if (model is null)
+        {
+            // User chose to go back to the menu
+            appLogger.LogReturnToMenu();
+
+            return;
+        }
+
+        appLogger.LogInformation(Emoji.Known.OkButton + " Selected model: {Model}", model);
+
+        var selectedPrinter   = await printers.SelectPrinterAsync(appLogger).ConfigureAwait(false);
+        var selectedFilaments = await filaments.SelectFilamentsAsync(appLogger);
+        var cost              = await "cost".GetInputFromConsoleAsync<decimal>().ConfigureAwait(false); // TODO: Calculate from filament and length
+        var dateSubmitted =
+            await "submitted".GetDateFromConsoleAsync(DateOnly.FromDateTime(DateTime.Today)).ConfigureAwait(false) ?? DateOnly.FromDateTime(DateTime.Today);
+        var dateCompleted = await "completed".GetDateFromConsoleAsync().ConfigureAwait(false);
+
+        appLogger.LogInformation(Emoji.Known.OkButton + " Set cost to {Cost}",                   cost.ToString("C2"));
+        appLogger.LogInformation(Emoji.Known.OkButton + " Set DateSubmitted to {DateSubmitted}", dateSubmitted.ToShortDateString());
+        if (dateCompleted.HasValue)
+        {
+            appLogger.LogInformation(Emoji.Known.OkButton + " Set DateCompleted to {DateCompleted}", dateCompleted.Value.ToShortDateString());
+        }
+        else
+        {
+            appLogger.LogInformation(Emoji.Known.OkButton + " Not completed");
+        }
+
+        await vm
+              .AddPrintingProjectAsync(new PrintingProjectDto(cost, dateSubmitted, dateCompleted, customer, model, selectedPrinter, selectedFilaments))
+              .ConfigureAwait(false);
+        appLogger.LogInformation(
+            Emoji.Known.CheckMarkButton + " Added project {Model} for {Customer} with filaments {Filaments}",
+            model,
+            customer,
+            string.Join(", ", selectedFilaments));
     }
 }

--- a/src/gcj/Actions/Add.cs
+++ b/src/gcj/Actions/Add.cs
@@ -144,6 +144,38 @@ public static partial class Program
         appLogger.LogInformation(Emoji.Known.CheckMarkButton + " Added model design {Summary}", summary);
     }
 
+    static async Task AddPrinterAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+    {
+        var manufacturer = await vm.SelectManufacturer().ConfigureAwait(false);
+        if (manufacturer is null)
+        {
+            appLogger.LogReturnToMenu();
+
+            return;
+        }
+
+        var model = await string.Empty.GetPrinterModel().ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(model))
+        {
+            appLogger.LogError(Emoji.Known.Warning + "  Model cannot be empty");
+
+            return;
+        }
+
+        var costPerHour = await 0m.GetPrinterCostPerHour().ConfigureAwait(false);
+        if (costPerHour <= 0)
+        {
+            appLogger.LogError(Emoji.Known.Warning + "  Cost per hour cannot be zero or negative");
+
+            return;
+        }
+
+        var printerDto = new PrinterDto(manufacturer, model, costPerHour);
+        await vm.AddPrinterAsync(printerDto).ConfigureAwait(false);
+        appLogger.LogInformation(Emoji.Known.CheckMarkButton + " Added Printer {Model}", printerDto);
+    }
+
     static async Task AddPrintingProjectAsync(IGCodeJournalViewModel vm, ILogger appLogger)
     {
         var customers = await vm.GetAllCustomersAsync().ConfigureAwait(false);

--- a/src/gcj/Actions/Delete.cs
+++ b/src/gcj/Actions/Delete.cs
@@ -189,6 +189,35 @@ public static partial class Program
         }
     }
 
+    static async Task DeletePrinterAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+    {
+        var printers        = await vm.GetAllPrintersAsync().ConfigureAwait(false);
+        var selectedPrinter = await printers.GetEntitySelectionAsync().ConfigureAwait(false);
+        if (selectedPrinter is null)
+        {
+            appLogger.LogReturnToMenu();
+
+            return;
+        }
+
+        if (await selectedPrinter.ConfirmDeleteAsync().ConfigureAwait(false))
+        {
+            var result = await vm.DeletePrinterAsync(selectedPrinter).ConfigureAwait(false);
+            if (result == ValidationResult.Success)
+            {
+                appLogger.DisplayDeleteConfirmedMessage<Printer>(selectedPrinter.ToString());
+            }
+            else
+            {
+                appLogger.LogSaveFailure(result);
+            }
+        }
+        else
+        {
+            appLogger.DisplayCancelDeleteMessage<ModelDesign>();
+        }
+    }
+
     static async Task DeletePrintingProjectAsync(IGCodeJournalViewModel vm, ILogger appLogger)
     {
         var allProjects = await vm.GetAllPrintingProjectsAsync().ConfigureAwait(false);

--- a/src/gcj/Actions/Edit.cs
+++ b/src/gcj/Actions/Edit.cs
@@ -241,6 +241,51 @@ public static partial class Program
         }
     }
 
+    static async Task EditPrinterAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+    {
+        var printers        = await vm.GetAllPrintersAsync().ConfigureAwait(false);
+        var selectedPrinter = await printers.GetEntitySelectionAsync().ConfigureAwait(false);
+        if (selectedPrinter is null)
+        {
+            appLogger.LogReturnToMenu();
+
+            return;
+        }
+
+        var manufacturer = await vm.SelectManufacturer().ConfigureAwait(false) ?? selectedPrinter.Manufacturer;
+
+        var model = await selectedPrinter.Model.GetPrinterModel().ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(model))
+        {
+            appLogger.LogError(Emoji.Known.Warning + "  Model cannot be empty");
+
+            return;
+        }
+
+        var costPerHour = await selectedPrinter.CostPerHour.GetPrinterCostPerHour().ConfigureAwait(false);
+        if (costPerHour <= 0)
+        {
+            appLogger.LogError(Emoji.Known.Warning + "  Cost per hour cannot be zero or negative");
+
+            return;
+        }
+
+        selectedPrinter.Manufacturer = manufacturer ?? selectedPrinter.Manufacturer;
+        selectedPrinter.Model        = model;
+        selectedPrinter.CostPerHour  = costPerHour;
+
+        var result = await vm.EditPrinterAsync(selectedPrinter).ConfigureAwait(false);
+        if (result == ValidationResult.Success)
+        {
+            appLogger.LogInformation(Emoji.Known.CheckMarkButton + "  Updated Printer {Printer}", selectedPrinter);
+        }
+        else
+        {
+            appLogger.LogSaveFailure(result);
+        }
+    }
+
     static async Task EditPrintingProjectAsync(IGCodeJournalViewModel vm, ILogger appLogger)
     {
         var allCustomers = await vm.GetAllCustomersAsync().ConfigureAwait(false);

--- a/src/gcj/Actions/Edit.cs
+++ b/src/gcj/Actions/Edit.cs
@@ -1,264 +1,289 @@
-﻿namespace gcj
+﻿// gcj
+
+namespace gcj;
+
+#region Using Directives
+using gCodeJournal.ViewModel;
+using gCodeJournal.ViewModel.DTOs;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using ValidationResult = System.ComponentModel.DataAnnotations.ValidationResult;
+#endregion
+
+public static partial class Program
 {
-    #region Using Directives
-    using gCodeJournal.ViewModel;
-    using Microsoft.Extensions.Logging;
-    using Spectre.Console;
-    using ValidationResult = System.ComponentModel.DataAnnotations.ValidationResult;
-    #endregion
-
-    public static partial class Program
+    static async Task EditCustomerAsync(IGCodeJournalViewModel vm, ILogger appLogger)
     {
-        private static async Task EditCustomerAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+        var customers = await vm.GetAllCustomersAsync().ConfigureAwait(false);
+        var customer  = await customers.GetEntitySelectionAsync().ConfigureAwait(false);
+        if (customer is null)
         {
-            var customers = await vm.GetAllCustomersAsync().ConfigureAwait(false);
-            var customer  = await customers.GetEntitySelectionAsync().ConfigureAwait(false);
-            if (customer is null)
-            {
-                appLogger.LogReturnToMenu();
-                return;
-            }
+            appLogger.LogReturnToMenu();
 
-            var customerName = await customer.Name.ValidateCustomerNameInputAsync(appLogger).ConfigureAwait(false);
-            if (string.IsNullOrWhiteSpace(customerName))
-            {
-                return;
-            }
-
-            customer.Name = customerName;
-            var result = await vm.EditCustomerAsync(customer).ConfigureAwait(false);
-            if (result == ValidationResult.Success)
-            {
-                appLogger.LogInformation(Emoji.Known.CheckMarkButton + "  Updated customer {CustomerName}", customer.Name);
-            }
-            else
-            {
-                appLogger.LogSaveFailure(result);
-            }
+            return;
         }
 
-        private static async Task EditFilamentAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+        var customerName = await customer.Name.ValidateCustomerNameInputAsync(appLogger).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(customerName))
         {
-            var colours       = await vm.GetAllFilamentColoursAsync().ConfigureAwait(false);
-            var filamentTypes = await vm.GetAllFilamentTypesAsync().ConfigureAwait(false);
-            var manufacturers = await vm.GetAllManufacturersAsync().ConfigureAwait(false);
-            var filaments     = await vm.GetAllFilamentsAsync().ConfigureAwait(false);
-            var filament      = await filaments.GetEntitySelectionAsync().ConfigureAwait(false);
-            if (filament is null)
-            {
-                appLogger.LogReturnToMenu();
-                return;
-            }
-
-            var newManufacturer = await manufacturers.GetEntitySelectionAsync().ConfigureAwait(false);
-            var newFilamentType = await filamentTypes.GetEntitySelectionAsync().ConfigureAwait(false);
-            var newColour       = await colours.GetEntitySelectionAsync().ConfigureAwait(false);
-            if (newColour is null || newFilamentType is null || newManufacturer is null)
-            {
-                appLogger.LogReturnToMenu();
-                return;
-            }
-
-            filament!.FilamentColour = newColour;
-            filament.FilamentType    = newFilamentType;
-            filament.Manufacturer    = newManufacturer;
-            filament.CostPerWeight   = await filament.CostPerWeight.GetFilamentCostPerWeightAsync().ConfigureAwait(false);
-            filament.ProductId       = await (filament.ProductId   ?? string.Empty).GetFilamentProductIdAsync().ConfigureAwait(false);
-            filament.ReorderLink     = await (filament.ReorderLink ?? string.Empty).GetFilamentReorderLinkAsync().ConfigureAwait(false);
-            var result = await vm.EditFilamentAsync(filament).ConfigureAwait(false);
-            if (result == ValidationResult.Success)
-            {
-                appLogger.LogInformation(Emoji.Known.CheckMarkButton + "  Updated filament {FilamentDescription}", filament);
-            }
-            else
-            {
-                appLogger.LogSaveFailure(result);
-            }
+            return;
         }
 
-        private static async Task EditFilamentColourAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+        customer.Name = customerName;
+        var result = await vm.EditCustomerAsync(customer).ConfigureAwait(false);
+        if (result == ValidationResult.Success)
         {
-            var colours        = await vm.GetAllFilamentColoursAsync().ConfigureAwait(false);
-            var selectedColour = await colours.GetEntitySelectionAsync().ConfigureAwait(false);
-            if (selectedColour is null)
-            {
-                appLogger.LogReturnToMenu();
-                return;
-            }
+            appLogger.LogInformation(Emoji.Known.CheckMarkButton + "  Updated customer {CustomerName}", customer.Name);
+        }
+        else
+        {
+            appLogger.LogSaveFailure(result);
+        }
+    }
 
-            var updatedDescription = await selectedColour.Description.GetFilamentColourAsync().ConfigureAwait(false);
-            if (string.IsNullOrWhiteSpace(updatedDescription))
-            {
-                "Description cannot be null; no changes made".DisplayWarningMessage();
-                appLogger.LogReturnToMenu();
-                return;
-            }
+    static async Task EditFilamentAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+    {
+        var colours       = await vm.GetAllFilamentColoursAsync().ConfigureAwait(false);
+        var filamentTypes = await vm.GetAllFilamentTypesAsync().ConfigureAwait(false);
+        var manufacturers = await vm.GetAllManufacturersAsync().ConfigureAwait(false);
+        var filaments     = await vm.GetAllFilamentsAsync().ConfigureAwait(false);
+        var filament      = await filaments.GetEntitySelectionAsync().ConfigureAwait(false);
+        if (filament is null)
+        {
+            appLogger.LogReturnToMenu();
 
-            if (updatedDescription.Equals(selectedColour.Description))
-            {
-                "No changes detected".DisplayWarningMessage();
-                appLogger.LogReturnToMenu();
-                return;
-            }
-
-            selectedColour.Description = updatedDescription;
-            var result = await vm.EditFilamentColourAsync(selectedColour).ConfigureAwait(false);
-            if (result == ValidationResult.Success)
-            {
-                appLogger.LogInformation(Emoji.Known.CheckMarkButton + "  Updated filament colour {FilamentDescription}", selectedColour);
-            }
-            else
-            {
-                appLogger.LogSaveFailure(result);
-            }
+            return;
         }
 
-        private static async Task EditFilamentTypeAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+        var newManufacturer = await manufacturers.GetEntitySelectionAsync().ConfigureAwait(false);
+        var newFilamentType = await filamentTypes.GetEntitySelectionAsync().ConfigureAwait(false);
+        var newColour       = await colours.GetEntitySelectionAsync().ConfigureAwait(false);
+        if (newColour is null || newFilamentType is null || newManufacturer is null)
         {
-            var filamentTypes        = await vm.GetAllFilamentTypesAsync().ConfigureAwait(false);
-            var selectedFilamentType = await filamentTypes.GetEntitySelectionAsync().ConfigureAwait(false);
-            if (selectedFilamentType is null)
-            {
-                appLogger.LogReturnToMenu();
-                return;
-            }
+            appLogger.LogReturnToMenu();
 
-            var updatedFilamentType = await selectedFilamentType.Description.GetFilamentTypeAsync().ConfigureAwait(false);
-            if (string.IsNullOrWhiteSpace(updatedFilamentType))
-            {
-                "Filament Type cannot be null; no changes made".DisplayWarningMessage();
-                appLogger.LogReturnToMenu();
-                return;
-            }
-
-            if (updatedFilamentType.Equals(selectedFilamentType.Description))
-            {
-                "No changes detected".DisplayWarningMessage();
-                appLogger.LogReturnToMenu();
-                return;
-            }
-
-            selectedFilamentType.Description = updatedFilamentType;
-            var result = await vm.EditFilamentTypeAsync(selectedFilamentType).ConfigureAwait(false);
-            if (result == ValidationResult.Success)
-            {
-                appLogger.LogInformation(Emoji.Known.CheckMarkButton + "  Updated Filament Type {FilamentType}", selectedFilamentType);
-            }
-            else
-            {
-                appLogger.LogSaveFailure(result);
-            }
+            return;
         }
 
-        private static async Task EditManufacturerAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+        filament!.FilamentColour = newColour;
+        filament.FilamentType    = newFilamentType;
+        filament.Manufacturer    = newManufacturer;
+        filament.CostPerWeight   = await filament.CostPerWeight.GetFilamentCostPerWeightAsync().ConfigureAwait(false);
+        filament.ProductId       = await (filament.ProductId   ?? string.Empty).GetFilamentProductIdAsync().ConfigureAwait(false);
+        filament.ReorderLink     = await (filament.ReorderLink ?? string.Empty).GetFilamentReorderLinkAsync().ConfigureAwait(false);
+        var result = await vm.EditFilamentAsync(filament).ConfigureAwait(false);
+        if (result == ValidationResult.Success)
         {
-            var manufacturers        = await vm.GetAllManufacturersAsync().ConfigureAwait(false);
-            var selectedManufacturer = await manufacturers.GetEntitySelectionAsync().ConfigureAwait(false);
-            if (selectedManufacturer is null)
-            {
-                appLogger.LogReturnToMenu();
-                return;
-            }
+            appLogger.LogInformation(Emoji.Known.CheckMarkButton + "  Updated filament {FilamentDescription}", filament);
+        }
+        else
+        {
+            appLogger.LogSaveFailure(result);
+        }
+    }
 
-            var updatedManufacturer = await selectedManufacturer.Name.GetManufacturerAsync().ConfigureAwait(false);
-            if (string.IsNullOrWhiteSpace(updatedManufacturer))
-            {
-                "Manufacturer name cannot be null; no changes made".DisplayWarningMessage();
-                appLogger.LogReturnToMenu();
-                return;
-            }
+    static async Task EditFilamentColourAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+    {
+        var colours        = await vm.GetAllFilamentColoursAsync().ConfigureAwait(false);
+        var selectedColour = await colours.GetEntitySelectionAsync().ConfigureAwait(false);
+        if (selectedColour is null)
+        {
+            appLogger.LogReturnToMenu();
 
-            if (updatedManufacturer.Equals(selectedManufacturer.Name))
-            {
-                "No changes detected".DisplayWarningMessage();
-                appLogger.LogReturnToMenu();
-                return;
-            }
-
-            selectedManufacturer.Name = updatedManufacturer;
-            var result = await vm.EditManufacturerAsync(selectedManufacturer).ConfigureAwait(false);
-            if (result == ValidationResult.Success)
-            {
-                appLogger.LogInformation(Emoji.Known.CheckMarkButton + "  Updated Manufacturer {Manufacturer}", selectedManufacturer);
-            }
-            else
-            {
-                appLogger.LogSaveFailure(result);
-            }
+            return;
         }
 
-        private static async Task EditModelDesignAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+        var updatedDescription = await selectedColour.Description.GetFilamentColourAsync().ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(updatedDescription))
         {
-            var designs        = await vm.GetAllModelDesignsAsync().ConfigureAwait(false);
-            var selectedDesign = await designs.GetEntitySelectionAsync().ConfigureAwait(false);
-            if (selectedDesign is null)
-            {
-                appLogger.LogReturnToMenu();
-                return;
-            }
+            "Description cannot be null; no changes made".DisplayWarningMessage();
+            appLogger.LogReturnToMenu();
 
-            var summary     = await selectedDesign.Summary.GetModelSummary().ConfigureAwait(false);
-            var description = await "[Press ENTER to retain existing description]".GetModelDescriptionAsync().ConfigureAwait(false);
-            var length      = await selectedDesign.Length.GetModelLengthAsync().ConfigureAwait(false);
-            var url         = await "model URL".GetUriAsync(selectedDesign.Url).ConfigureAwait(false);
-
-            if (string.IsNullOrWhiteSpace(summary))
-            {
-                appLogger.LogWarning("Summary cannot be empty");
-                appLogger.LogReturnToMenu();
-                return;
-            }
-
-            selectedDesign.Description = description ?? selectedDesign.Description;
-            selectedDesign.Summary     = summary;
-            selectedDesign.Length      = length;
-            selectedDesign.Url         = url;
-
-            var result = await vm.EditModelDesignAsync(selectedDesign).ConfigureAwait(false);
-            if (result == ValidationResult.Success)
-            {
-                appLogger.LogInformation(Emoji.Known.CheckMarkButton + "  Updated Model {ModelDesign}", selectedDesign);
-            }
-            else
-            {
-                appLogger.LogSaveFailure(result);
-            }
+            return;
         }
 
-        private static async Task EditPrintingProjectAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+        if (updatedDescription.Equals(selectedColour.Description))
         {
-            var allCustomers = await vm.GetAllCustomersAsync().ConfigureAwait(false);
-            var allModels    = await vm.GetAllModelDesignsAsync().ConfigureAwait(false);
-            var allFilaments = await vm.GetAllFilamentsAsync().ConfigureAwait(false);
-            var allProjects  = await vm.GetAllPrintingProjectsAsync().ConfigureAwait(false);
+            "No changes detected".DisplayWarningMessage();
+            appLogger.LogReturnToMenu();
 
-            var selectedProject = await allProjects.GetEntitySelectionAsync().ConfigureAwait(false);
-            if (selectedProject is null)
-            {
-                appLogger.LogReturnToMenu();
-                return;
-            }
-
-            var customer  = await allCustomers.GetEntitySelectionAsync().ConfigureAwait(false);
-            var model     = await allModels.GetEntitySelectionAsync().ConfigureAwait(false);
-            var filaments = await allFilaments.SelectFilamentsAsync(appLogger, selectedProject.Filaments);
-
-            selectedProject.Customer = customer ?? selectedProject.Customer;
-            selectedProject.Filaments = filaments.Any() ? filaments : selectedProject.Filaments;
-            selectedProject.Cost = await "cost".GetInputFromConsoleAsync<decimal>().ConfigureAwait(false); // TODO: Calculate from filament and length
-            selectedProject.Submitted = await "submitted".GetDateFromConsoleAsync(selectedProject.Submitted).ConfigureAwait(false) ?? DateOnly.FromDateTime(DateTime.Today);
-            selectedProject.Completed = await "completed".GetDateFromConsoleAsync(selectedProject.Completed).ConfigureAwait(false);
-            selectedProject.ModelDesign = model ?? selectedProject.ModelDesign;
-
-            var result = await vm.EditPrintingProjectAsync(selectedProject).ConfigureAwait(false);
-            if (result == ValidationResult.Success)
-            {
-                appLogger.LogInformation(Emoji.Known.CheckMarkButton + "  Updated Project {Project}", selectedProject);
-            }
-            else
-            {
-                appLogger.LogSaveFailure(result);
-            }
+            return;
         }
+
+        selectedColour.Description = updatedDescription;
+        var result = await vm.EditFilamentColourAsync(selectedColour).ConfigureAwait(false);
+        if (result == ValidationResult.Success)
+        {
+            appLogger.LogInformation(Emoji.Known.CheckMarkButton + "  Updated filament colour {FilamentDescription}", selectedColour);
+        }
+        else
+        {
+            appLogger.LogSaveFailure(result);
+        }
+    }
+
+    static async Task EditFilamentTypeAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+    {
+        var filamentTypes        = await vm.GetAllFilamentTypesAsync().ConfigureAwait(false);
+        var selectedFilamentType = await filamentTypes.GetEntitySelectionAsync().ConfigureAwait(false);
+        if (selectedFilamentType is null)
+        {
+            appLogger.LogReturnToMenu();
+
+            return;
+        }
+
+        var updatedFilamentType = await selectedFilamentType.Description.GetFilamentTypeAsync().ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(updatedFilamentType))
+        {
+            "Filament Type cannot be null; no changes made".DisplayWarningMessage();
+            appLogger.LogReturnToMenu();
+
+            return;
+        }
+
+        if (updatedFilamentType.Equals(selectedFilamentType.Description))
+        {
+            "No changes detected".DisplayWarningMessage();
+            appLogger.LogReturnToMenu();
+
+            return;
+        }
+
+        selectedFilamentType.Description = updatedFilamentType;
+        var result = await vm.EditFilamentTypeAsync(selectedFilamentType).ConfigureAwait(false);
+        if (result == ValidationResult.Success)
+        {
+            appLogger.LogInformation(Emoji.Known.CheckMarkButton + "  Updated Filament Type {FilamentType}", selectedFilamentType);
+        }
+        else
+        {
+            appLogger.LogSaveFailure(result);
+        }
+    }
+
+    static async Task EditManufacturerAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+    {
+        var selectedManufacturer = await vm.SelectManufacturer().ConfigureAwait(false);
+        if (selectedManufacturer is null)
+        {
+            appLogger.LogReturnToMenu();
+
+            return;
+        }
+
+        var updatedManufacturer = await selectedManufacturer.Name.GetManufacturerAsync().ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(updatedManufacturer))
+        {
+            "Manufacturer name cannot be null; no changes made".DisplayWarningMessage();
+            appLogger.LogReturnToMenu();
+
+            return;
+        }
+
+        if (updatedManufacturer.Equals(selectedManufacturer.Name))
+        {
+            "No changes detected".DisplayWarningMessage();
+            appLogger.LogReturnToMenu();
+
+            return;
+        }
+
+        selectedManufacturer.Name = updatedManufacturer;
+        var result = await vm.EditManufacturerAsync(selectedManufacturer).ConfigureAwait(false);
+        if (result == ValidationResult.Success)
+        {
+            appLogger.LogInformation(Emoji.Known.CheckMarkButton + "  Updated Manufacturer {Manufacturer}", selectedManufacturer);
+        }
+        else
+        {
+            appLogger.LogSaveFailure(result);
+        }
+    }
+
+    static async Task EditModelDesignAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+    {
+        var designs        = await vm.GetAllModelDesignsAsync().ConfigureAwait(false);
+        var selectedDesign = await designs.GetEntitySelectionAsync().ConfigureAwait(false);
+        if (selectedDesign is null)
+        {
+            appLogger.LogReturnToMenu();
+
+            return;
+        }
+
+        var summary     = await selectedDesign.Summary.GetModelSummary().ConfigureAwait(false);
+        var description = await "[Press ENTER to retain existing description]".GetModelDescriptionAsync().ConfigureAwait(false);
+        var length      = await selectedDesign.Length.GetModelLengthAsync().ConfigureAwait(false);
+        var url         = await "model URL".GetUriAsync(selectedDesign.Url).ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(summary))
+        {
+            appLogger.LogWarning("Summary cannot be empty");
+            appLogger.LogReturnToMenu();
+
+            return;
+        }
+
+        selectedDesign.Description = description ?? selectedDesign.Description;
+        selectedDesign.Summary     = summary;
+        selectedDesign.Length      = length;
+        selectedDesign.Url         = url;
+
+        var result = await vm.EditModelDesignAsync(selectedDesign).ConfigureAwait(false);
+        if (result == ValidationResult.Success)
+        {
+            appLogger.LogInformation(Emoji.Known.CheckMarkButton + "  Updated Model {ModelDesign}", selectedDesign);
+        }
+        else
+        {
+            appLogger.LogSaveFailure(result);
+        }
+    }
+
+    static async Task EditPrintingProjectAsync(IGCodeJournalViewModel vm, ILogger appLogger)
+    {
+        var allCustomers = await vm.GetAllCustomersAsync().ConfigureAwait(false);
+        var allModels    = await vm.GetAllModelDesignsAsync().ConfigureAwait(false);
+        var allFilaments = await vm.GetAllFilamentsAsync().ConfigureAwait(false);
+        var allProjects  = await vm.GetAllPrintingProjectsAsync().ConfigureAwait(false);
+
+        var selectedProject = await allProjects.GetEntitySelectionAsync().ConfigureAwait(false);
+        if (selectedProject is null)
+        {
+            appLogger.LogReturnToMenu();
+
+            return;
+        }
+
+        var customer  = await allCustomers.GetEntitySelectionAsync().ConfigureAwait(false);
+        var model     = await allModels.GetEntitySelectionAsync().ConfigureAwait(false);
+        var filaments = await allFilaments.SelectFilamentsAsync(appLogger, selectedProject.Filaments);
+
+        selectedProject.Customer  = customer ?? selectedProject.Customer;
+        selectedProject.Filaments = filaments.Any() ? filaments : selectedProject.Filaments;
+        selectedProject.Cost      = await "cost".GetInputFromConsoleAsync<decimal>().ConfigureAwait(false); // TODO: Calculate from filament and length
+        selectedProject.Submitted =
+            await "submitted".GetDateFromConsoleAsync(selectedProject.Submitted).ConfigureAwait(false) ?? DateOnly.FromDateTime(DateTime.Today);
+        selectedProject.Completed   = await "completed".GetDateFromConsoleAsync(selectedProject.Completed).ConfigureAwait(false);
+        selectedProject.ModelDesign = model ?? selectedProject.ModelDesign;
+
+        var result = await vm.EditPrintingProjectAsync(selectedProject).ConfigureAwait(false);
+        if (result == ValidationResult.Success)
+        {
+            appLogger.LogInformation(Emoji.Known.CheckMarkButton + "  Updated Project {Project}", selectedProject);
+        }
+        else
+        {
+            appLogger.LogSaveFailure(result);
+        }
+    }
+
+    static async Task<ManufacturerDto?> SelectManufacturer(this IGCodeJournalViewModel vm)
+    {
+        var manufacturers        = await vm.GetAllManufacturersAsync().ConfigureAwait(false);
+        var selectedManufacturer = await manufacturers.GetEntitySelectionAsync().ConfigureAwait(false);
+
+        return selectedManufacturer;
     }
 }

--- a/src/gcj/ConsoleExtensions.cs
+++ b/src/gcj/ConsoleExtensions.cs
@@ -128,6 +128,12 @@ internal static class ConsoleExtensions
                         });
     }
 
+    public static async Task<decimal> GetPrinterCostPerHour(this decimal defaultValue) =>
+        await "printer cost per hour".GetInputFromConsoleAsync(defaultValue).ConfigureAwait(false);
+
+    public static async Task<string> GetPrinterModel(this string defaultValue) =>
+        await "printer model".GetInputFromConsoleAsync(defaultValue).ConfigureAwait(false) ?? string.Empty;
+
     public static async Task<string?> GetUriAsync(this string promptMessage, string? defaultValue = null)
     {
         var uri = await promptMessage.GetInputFromConsoleAsync(defaultValue).ConfigureAwait(false);

--- a/src/gcj/ConsoleExtensions.cs
+++ b/src/gcj/ConsoleExtensions.cs
@@ -18,8 +18,9 @@ internal static class ConsoleExtensions
 
     public static async Task<bool> ConfirmDeleteAsync<T>(this T objectType) where T : class
     {
-        var confirmationPrompt = new ConfirmationPrompt($"Are you sure you want to delete the {typeof(T)} ({objectType})?") {DefaultValue = false};
-        var result             = await AnsiConsole.PromptAsync(confirmationPrompt).ConfigureAwait(false);
+        var confirmationPrompt =
+            new ConfirmationPrompt($"Are you sure you want to delete the {typeof(T).Name.HumanizeDtoName()} '{objectType}'y?") {DefaultValue = false};
+        var result = await AnsiConsole.PromptAsync(confirmationPrompt).ConfigureAwait(false);
 
         return result;
     }

--- a/src/gcj/DbRunner.cs
+++ b/src/gcj/DbRunner.cs
@@ -221,6 +221,10 @@ public static partial class Program
                         await AddModelDesignAsync(vm, appLogger).ConfigureAwait(false);
 
                         return;
+                    case var _ when target.Equals("Printer", StringComparison.OrdinalIgnoreCase):
+                        await AddPrinterAsync(vm, appLogger).ConfigureAwait(false);
+
+                        return;
                     case var _ when target.Equals("PrintingProject", StringComparison.OrdinalIgnoreCase):
                         await AddPrintingProjectAsync(vm, appLogger).ConfigureAwait(false);
 

--- a/src/gcj/DbRunner.cs
+++ b/src/gcj/DbRunner.cs
@@ -263,6 +263,10 @@ public static partial class Program
                         await EditModelDesignAsync(vm, appLogger).ConfigureAwait(false);
 
                         return;
+                    case var _ when target.Equals("Printer", StringComparison.OrdinalIgnoreCase):
+                        await EditPrinterAsync(vm, appLogger).ConfigureAwait(false);
+
+                        return;
                     case var _ when target.Equals("PrintingProject", StringComparison.OrdinalIgnoreCase):
                         await EditPrintingProjectAsync(vm, appLogger).ConfigureAwait(false);
 
@@ -299,6 +303,10 @@ public static partial class Program
                         return;
                     case var _ when target.Equals("ModelDesign", StringComparison.OrdinalIgnoreCase):
                         await DeleteModelDesignAsync(vm, appLogger).ConfigureAwait(false);
+
+                        return;
+                    case var _ when target.Equals("Printer", StringComparison.OrdinalIgnoreCase):
+                        await DeletePrinterAsync(vm, appLogger).ConfigureAwait(false);
 
                         return;
                     case var _ when target.Equals("PrintingProject", StringComparison.OrdinalIgnoreCase):

--- a/src/gcj/DbRunner.cs
+++ b/src/gcj/DbRunner.cs
@@ -1,3 +1,5 @@
+// gcj
+
 namespace gcj;
 
 #region Using Directives
@@ -11,7 +13,7 @@ using Spectre.Console;
 
 public static partial class Program
 {
-    private static async Task LogCustomerDetailsAsync(IGCodeJournalViewModel vm, ILogger logger)
+    static async Task LogCustomerDetailsAsync(IGCodeJournalViewModel vm, ILogger logger)
     {
         // Extract data from the database before writing to the console; this will log any warnings if we're logging sensitive data
         var customers = await vm.GetAllCustomersAsync().ConfigureAwait(false);
@@ -22,7 +24,7 @@ public static partial class Program
         }
     }
 
-    private static async Task LogFilamentColourDetailsAsync(IGCodeJournalViewModel vm, ILogger logger)
+    static async Task LogFilamentColourDetailsAsync(IGCodeJournalViewModel vm, ILogger logger)
     {
         logger.LogInformation("Filament Colours:");
         var colours = await vm.GetAllFilamentColoursAsync().ConfigureAwait(false);
@@ -32,7 +34,7 @@ public static partial class Program
         }
     }
 
-    private static async Task LogFilamentDetailsAsync(IGCodeJournalViewModel vm, ILogger logger)
+    static async Task LogFilamentDetailsAsync(IGCodeJournalViewModel vm, ILogger logger)
     {
         logger.LogInformation("Filaments:");
         var filaments = await vm.GetAllFilamentsAsync().ConfigureAwait(false);
@@ -42,7 +44,7 @@ public static partial class Program
         }
     }
 
-    private static async Task LogFilamentTypeDetailsAsync(IGCodeJournalViewModel vm, ILogger logger)
+    static async Task LogFilamentTypeDetailsAsync(IGCodeJournalViewModel vm, ILogger logger)
     {
         logger.LogInformation("Filament Types:");
         var types = await vm.GetAllFilamentTypesAsync().ConfigureAwait(false);
@@ -52,7 +54,7 @@ public static partial class Program
         }
     }
 
-    private static async Task LogManufacturerDetailsAsync(IGCodeJournalViewModel vm, ILogger logger)
+    static async Task LogManufacturerDetailsAsync(IGCodeJournalViewModel vm, ILogger logger)
     {
         // Get and log Manufacturers and Filaments
         var manufacturers = await vm.GetAllManufacturersAsync().ConfigureAwait(false);
@@ -63,7 +65,7 @@ public static partial class Program
         }
     }
 
-    private static async Task LogModelDesignDetailsAsync(IGCodeJournalViewModel vm, ILogger logger)
+    static async Task LogModelDesignDetailsAsync(IGCodeJournalViewModel vm, ILogger logger)
     {
         logger.LogInformation("Model Designs:");
         var models = await vm.GetAllModelDesignsAsync().ConfigureAwait(false);
@@ -73,7 +75,17 @@ public static partial class Program
         }
     }
 
-    private static async Task LogPrintingProjectDetailsAsync(IGCodeJournalViewModel vm, ILogger logger)
+    static async Task LogPrinterDetailsAsync(IGCodeJournalViewModel vm, ILogger logger)
+    {
+        logger.LogInformation("Printers:");
+        var printers = await vm.GetAllPrintersAsync().ConfigureAwait(false);
+        foreach (var printer in printers)
+        {
+            logger.LogInformation(" {PrinterId}: {Printer}", printer.Id, printer);
+        }
+    }
+
+    static async Task LogPrintingProjectDetailsAsync(IGCodeJournalViewModel vm, ILogger logger)
     {
         logger.LogInformation("Printing Projects:");
         var projects = await vm.GetAllPrintingProjectsAsync().ConfigureAwait(false);
@@ -83,7 +95,7 @@ public static partial class Program
         }
     }
 
-    private static async Task ProcessDatabaseActionAsync(string commandRequested, ServiceProvider provider, ILogger appLogger)
+    static async Task ProcessDatabaseActionAsync(string commandRequested, ServiceProvider provider, ILogger appLogger)
     {
         using var scope = provider.CreateScope();
         var       vm    = scope.ServiceProvider.GetRequiredService<IGCodeJournalViewModel>();
@@ -108,6 +120,7 @@ public static partial class Program
                 if (action.Equals("customers", StringComparison.OrdinalIgnoreCase) || target.Equals("customers", StringComparison.OrdinalIgnoreCase))
                 {
                     await LogCustomerDetailsAsync(vm, appLogger).ConfigureAwait(false);
+
                     return;
                 }
 
@@ -118,12 +131,14 @@ public static partial class Program
                     || target.Equals("filamentColors", StringComparison.OrdinalIgnoreCase))
                 {
                     await LogFilamentColourDetailsAsync(vm, appLogger).ConfigureAwait(false);
+
                     return;
                 }
 
                 if (action.Equals("filaments", StringComparison.OrdinalIgnoreCase) || target.Equals("filaments", StringComparison.OrdinalIgnoreCase))
                 {
                     await LogFilamentDetailsAsync(vm, appLogger).ConfigureAwait(false);
+
                     return;
                 }
 
@@ -131,12 +146,14 @@ public static partial class Program
                 if (action.Equals("filamentTypes", StringComparison.OrdinalIgnoreCase) || target.Equals("filamentTypes", StringComparison.OrdinalIgnoreCase))
                 {
                     await LogFilamentTypeDetailsAsync(vm, appLogger).ConfigureAwait(false);
+
                     return;
                 }
 
                 if (action.Equals("manufacturers", StringComparison.OrdinalIgnoreCase) || target.Equals("manufacturers", StringComparison.OrdinalIgnoreCase))
                 {
                     await LogManufacturerDetailsAsync(vm, appLogger).ConfigureAwait(false);
+
                     return;
                 }
 
@@ -146,6 +163,17 @@ public static partial class Program
                     || target.Equals("modelDesign",  StringComparison.OrdinalIgnoreCase))
                 {
                     await LogModelDesignDetailsAsync(vm, appLogger).ConfigureAwait(false);
+
+                    return;
+                }
+
+                // Handle printers
+                if (action.Equals("printers", StringComparison.OrdinalIgnoreCase)
+                    || target.Equals("printers", StringComparison.OrdinalIgnoreCase)
+                    || target.Equals("printer",  StringComparison.OrdinalIgnoreCase))
+                {
+                    await LogPrinterDetailsAsync(vm, appLogger).ConfigureAwait(false);
+
                     return;
                 }
 
@@ -156,6 +184,7 @@ public static partial class Program
                     || target.Equals("projects", StringComparison.OrdinalIgnoreCase))
                 {
                     await LogPrintingProjectDetailsAsync(vm, appLogger).ConfigureAwait(false);
+
                     return;
                 }
 
@@ -169,25 +198,32 @@ public static partial class Program
                 {
                     case var _ when target.Equals("Customer", StringComparison.OrdinalIgnoreCase):
                         await AddCustomerAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                     case var _ when target.Equals("Filament", StringComparison.OrdinalIgnoreCase):
                         await AddFilamentAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                     case var _ when target.Equals("FilamentColour",   StringComparison.OrdinalIgnoreCase)
                                     || target.Equals("FilamentColor", StringComparison.OrdinalIgnoreCase):
                         await AddFilamentColourAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                     case var _ when target.Equals("FilamentType", StringComparison.OrdinalIgnoreCase):
                         await AddFilamentTypeAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                     case var _ when target.Equals("Manufacturer", StringComparison.OrdinalIgnoreCase):
                         await AddManufacturerAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                     case var _ when target.Equals("ModelDesign", StringComparison.OrdinalIgnoreCase):
                         await AddModelDesignAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                     case var _ when target.Equals("PrintingProject", StringComparison.OrdinalIgnoreCase):
                         await AddPrintingProjectAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                 }
 
@@ -200,25 +236,32 @@ public static partial class Program
                 {
                     case var _ when target.Equals("Customer", StringComparison.OrdinalIgnoreCase):
                         await EditCustomerAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                     case var _ when target.Equals("Filament", StringComparison.OrdinalIgnoreCase):
                         await EditFilamentAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                     case var _ when target.Equals("FilamentColour",   StringComparison.OrdinalIgnoreCase)
                                     || target.Equals("FilamentColor", StringComparison.OrdinalIgnoreCase):
                         await EditFilamentColourAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                     case var _ when target.Equals("FilamentType", StringComparison.OrdinalIgnoreCase):
                         await EditFilamentTypeAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                     case var _ when target.Equals("Manufacturer", StringComparison.OrdinalIgnoreCase):
                         await EditManufacturerAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                     case var _ when target.Equals("ModelDesign", StringComparison.OrdinalIgnoreCase):
                         await EditModelDesignAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                     case var _ when target.Equals("PrintingProject", StringComparison.OrdinalIgnoreCase):
                         await EditPrintingProjectAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                 }
 
@@ -231,25 +274,32 @@ public static partial class Program
                 {
                     case var _ when target.Equals("Customer", StringComparison.OrdinalIgnoreCase):
                         await DeleteCustomerAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                     case var _ when target.Equals("Filament", StringComparison.OrdinalIgnoreCase):
                         await DeleteFilamentAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                     case var _ when target.Equals("FilamentColour",   StringComparison.OrdinalIgnoreCase)
                                     || target.Equals("FilamentColor", StringComparison.OrdinalIgnoreCase):
                         await DeleteFilamentColourAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                     case var _ when target.Equals("FilamentType", StringComparison.OrdinalIgnoreCase):
                         await DeleteFilamentTypeAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                     case var _ when target.Equals("Manufacturer", StringComparison.OrdinalIgnoreCase):
                         await DeleteManufacturerAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                     case var _ when target.Equals("ModelDesign", StringComparison.OrdinalIgnoreCase):
                         await DeleteModelDesignAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                     case var _ when target.Equals("PrintingProject", StringComparison.OrdinalIgnoreCase):
                         await DeletePrintingProjectAsync(vm, appLogger).ConfigureAwait(false);
+
                         return;
                 }
 
@@ -265,15 +315,19 @@ public static partial class Program
         {
             case "Customers":
                 await LogCustomerDetailsAsync(vm, appLogger).ConfigureAwait(false);
+
                 break;
             case "Manufacturers":
                 await LogManufacturerDetailsAsync(vm, appLogger).ConfigureAwait(false);
+
                 break;
             case "Filaments":
                 await LogFilamentDetailsAsync(vm, appLogger).ConfigureAwait(false);
+
                 break;
             default:
                 appLogger.LogWarning(Emoji.Known.Warning + "  Unhandled section '{Action}' / action '{Command}'", action, commandRequested);
+
                 break;
         }
     }
@@ -284,7 +338,7 @@ public static partial class Program
     ///     - remainder: the remainder of the action after the matched SubMenu entry
     ///     If no SubMenu value matches the start, returns (first token, remainder).
     /// </summary>
-    private static (string FirstPart, string Remainder) SplitActionIntoSubmenuAndRemainder(string action)
+    static (string FirstPart, string Remainder) SplitActionIntoSubmenuAndRemainder(string action)
     {
         if (string.IsNullOrWhiteSpace(action))
         {
@@ -303,6 +357,7 @@ public static partial class Program
             }
 
             var remainder = trimmed[sub.Length..].Trim().Dehumanize();
+
             return (sub, remainder);
         }
 
@@ -327,6 +382,7 @@ public static partial class Program
 
         // Fallback: split on the first whitespace token
         var firstSpace = trimmed.IndexOf(' ');
+
         return firstSpace < 0 ? (trimmed, string.Empty) : (trimmed[..firstSpace], trimmed[(firstSpace + 1)..].Trim());
     }
 }

--- a/src/gcj/Extensions/Extensions.cs
+++ b/src/gcj/Extensions/Extensions.cs
@@ -78,4 +78,19 @@ public static partial class Program
 
         return selectedFilaments;
     }
+
+    static async Task<PrinterDto?> SelectPrinterAsync(this List<PrinterDto> printers, ILogger appLogger, PrinterDto? currentPrinter = null)
+    {
+        //var selectedPrinter = currentPrinter;
+        var selected = await printers.GetEntitySelectionAsync().ConfigureAwait(false);
+        if (selected is null)
+        {
+            // User chose to return immediately -> cancel project creation.
+            return currentPrinter;
+        }
+
+        appLogger.LogInformation(Emoji.Known.OkButton + " Selected printer {Printer}", selected);
+
+        return selected;
+    }
 }

--- a/src/gcj/Menu.cs
+++ b/src/gcj/Menu.cs
@@ -24,6 +24,7 @@ public static partial class Program
     const string MenuImportData        = "Import data";
     const string MenuManufacturers     = "Manufacturers";
     const string MenuModelDesigns      = "Model Designs";
+    const string MenuPrinters          = "Printers";
     const string MenuPrintingProjects  = "Printing Projects";
     const string SubMenuAddNew         = "Add New";
     const string SubMenuBackToMain     = "Back to Main Menu";
@@ -41,6 +42,7 @@ public static partial class Program
         MenuFilaments,
         MenuFilamentTypes,
         MenuModelDesigns,
+        MenuPrinters,
         MenuPrintingProjects,
         MenuImportData,
         MenuExit

--- a/src/gcj/gcj.csproj
+++ b/src/gcj/gcj.csproj
@@ -8,6 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.10">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Humanizer" Version="2.14.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.10" />


### PR DESCRIPTION
Added `Printers` table, linked to `PrintingProjects` and `Manufacturers`.

```mermaid
graph LR
M["Manufacturer\n- Id\n- Name\n- IsPrinterManufacturer\n- IsFilamentManufacturer"]
P["Printer\n- Id\n- Model\n- ManufacturerId\n- CostPerHour"]
PP["PrintingProject\n- Id\n- Submitted\n- Completed\n- Cost\n- CustomerId\n- ModelDesignId"]

M -->|1..*| P
P -->|1..*| PP
```

Printers also have support for a `CostPerHour` figure, which will be taken into account when calculating costs.

Added console support for managing printers using List/Add/Modify/Delete commands.